### PR TITLE
FEAT: Display Hán‑Việt meanings in Lessons and standardize vocabulary card layout

### DIFF
--- a/augment_kanji.js
+++ b/augment_kanji.js
@@ -1,0 +1,131 @@
+// Augment lesson JSON files (1..22) with Mazii kanji search results
+// For each entry with non-empty `kanji`, call Mazii API and attach
+// `kanji_search_results`: [{ kanji: string, mean: string }]
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const LESSON_DIR = path.join(__dirname, 'data');
+const INTRO_FILE = 'introduction_vocabulary.json';
+const LESSON_PREFIX = 'lesson_';
+const LESSON_SUFFIX = '_vocabulary.json';
+const START = 1;
+const END = 22;
+
+// Simple in-memory cache to avoid duplicate API calls within one run
+const kanjiCache = new Map(); // key: kanji string, value: [{ kanji, mean }]
+
+function readJsonFile(filePath) {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+function writeJsonFile(filePath, data) {
+    // Preserve 2-space indentation consistent with existing files
+    const content = JSON.stringify(data, null, 2) + '\n';
+    fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function maziiRequestBody(kanjiText) {
+    return JSON.stringify({
+        dict: 'javi',
+        type: 'kanji',
+        query: kanjiText,
+        page: 1,
+    });
+}
+
+function callMazii(kanjiText) {
+    if (!kanjiText || !kanjiText.trim()) return Promise.resolve([]);
+    if (kanjiCache.has(kanjiText)) return Promise.resolve(kanjiCache.get(kanjiText));
+
+    const body = maziiRequestBody(kanjiText);
+
+    const options = {
+        method: 'POST',
+        hostname: 'mazii.net',
+        path: '/api/search/kanji',
+        headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+        },
+    };
+
+    return new Promise((resolve) => {
+        const req = https.request(options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                try {
+                    const json = JSON.parse(data);
+                    const results = Array.isArray(json.results) ? json.results : [];
+                    const simplified = results
+                        .map((r) => ({ kanji: r.kanji, mean: r.mean }))
+                        .filter((r) => typeof r.kanji === 'string' && r.kanji.trim().length > 0);
+                    kanjiCache.set(kanjiText, simplified);
+                    resolve(simplified);
+                } catch (_) {
+                    resolve([]);
+                }
+            });
+        });
+
+        req.on('error', () => resolve([]));
+        req.write(body);
+        req.end();
+    });
+}
+
+async function augmentFile(filePath) {
+    const data = readJsonFile(filePath);
+    if (!Array.isArray(data)) {
+        console.warn(`Skip non-array JSON: ${filePath}`);
+        return;
+    }
+
+    for (let i = 0; i < data.length; i++) {
+        const entry = data[i];
+        const kanjiText = typeof entry.kanji === 'string' ? entry.kanji.trim() : '';
+        if (!kanjiText) continue;
+
+        // If already present, skip to avoid re-calling and rewriting
+        if (Array.isArray(entry.kanji_search_results) && entry.kanji_search_results.length > 0) continue;
+
+        try {
+            const results = await callMazii(kanjiText);
+            if (results.length > 0) {
+                entry.kanji_search_results = results;
+            }
+        } catch (_) {
+            // Ignore errors, continue
+        }
+    }
+
+    writeJsonFile(filePath, data);
+}
+
+async function main() {
+    const targets = [];
+    for (let n = START; n <= END; n++) {
+        targets.push(path.join(LESSON_DIR, `${LESSON_PREFIX}${n}${LESSON_SUFFIX}`));
+    }
+
+    for (const file of targets) {
+        if (!fs.existsSync(file)) {
+            console.warn(`Missing file: ${file}`);
+            continue;
+        }
+        console.log(`Augmenting: ${path.basename(file)}`);
+        await augmentFile(file);
+    }
+
+    console.log('Done.');
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});
+
+

--- a/data/lesson_10_vocabulary.json
+++ b/data/lesson_10_vocabulary.json
@@ -200,12 +200,12 @@
     "example": "子供さんは何人ですか。",
     "kanji_search_results": [
       {
-        "kanji": "供",
-        "mean": "CUNG"
-      },
-      {
         "kanji": "子",
         "mean": "TỬ, TÍ"
+      },
+      {
+        "kanji": "供",
+        "mean": "CUNG"
       }
     ]
   },
@@ -362,16 +362,16 @@
     "example": "航空便で送ります。",
     "kanji_search_results": [
       {
+        "kanji": "航",
+        "mean": "HÀNG"
+      },
+      {
         "kanji": "空",
         "mean": "KHÔNG, KHỐNG, KHỔNG"
       },
       {
         "kanji": "便",
         "mean": "TIỆN"
-      },
-      {
-        "kanji": "航",
-        "mean": "HÀNG"
       }
     ]
   },

--- a/data/lesson_10_vocabulary.json
+++ b/data/lesson_10_vocabulary.json
@@ -27,7 +27,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "object",
-    "example": "絵はがきを送ります。"
+    "example": "絵はがきを送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "絵",
+        "mean": "HỘI"
+      }
+    ]
   },
   {
     "japanese": "せんぱい",
@@ -37,7 +43,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "person",
-    "example": "先輩に教えてもらいます。"
+    "example": "先輩に教えてもらいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      },
+      {
+        "kanji": "輩",
+        "mean": "BỐI"
+      }
+    ]
   },
   {
     "japanese": "こうはい",
@@ -47,7 +63,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "person",
-    "example": "後輩を教えます。"
+    "example": "後輩を教えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "後",
+        "mean": "HẬU, HẤU"
+      },
+      {
+        "kanji": "輩",
+        "mean": "BỐI"
+      }
+    ]
   },
   {
     "japanese": "おちゃ",
@@ -57,7 +83,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "food",
-    "example": "お茶を飲みます。"
+    "example": "お茶を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "茶",
+        "mean": "TRÀ"
+      }
+    ]
   },
   {
     "japanese": "ネックレス",
@@ -97,7 +129,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "family",
-    "example": "夫は会社員です。"
+    "example": "夫は会社員です。",
+    "kanji_search_results": [
+      {
+        "kanji": "夫",
+        "mean": "PHU, PHÙ"
+      }
+    ]
   },
   {
     "japanese": "しゅじん",
@@ -107,7 +145,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "family",
-    "example": "ご主人はお元気ですか。"
+    "example": "ご主人はお元気ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "主",
+        "mean": "CHỦ, CHÚA"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "つま",
@@ -117,7 +165,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "family",
-    "example": "妻は看護師です。"
+    "example": "妻は看護師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "妻",
+        "mean": "THÊ, THẾ"
+      }
+    ]
   },
   {
     "japanese": "おくさん",
@@ -127,7 +181,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "family",
-    "example": "奥さんはお元気ですか。"
+    "example": "奥さんはお元気ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "奥",
+        "mean": "ÁO, ÚC"
+      }
+    ]
   },
   {
     "japanese": "こどもさん",
@@ -137,7 +197,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "family",
-    "example": "子供さんは何人ですか。"
+    "example": "子供さんは何人ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "供",
+        "mean": "CUNG"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "せっけん",
@@ -147,7 +217,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "object",
-    "example": "石けんで手を洗います。"
+    "example": "石けんで手を洗います。",
+    "kanji_search_results": [
+      {
+        "kanji": "石",
+        "mean": "THẠCH"
+      }
+    ]
   },
   {
     "japanese": "みかん",
@@ -167,7 +243,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "注文をします。"
+    "example": "注文をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "注",
+        "mean": "CHÚ"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "サンドイッチ",
@@ -247,7 +333,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "body",
-    "example": "手を洗います。"
+    "example": "手を洗います。",
+    "kanji_search_results": [
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "レポート",
@@ -267,7 +359,21 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "service",
-    "example": "航空便で送ります。"
+    "example": "航空便で送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "空",
+        "mean": "KHÔNG, KHỐNG, KHỔNG"
+      },
+      {
+        "kanji": "便",
+        "mean": "TIỆN"
+      },
+      {
+        "kanji": "航",
+        "mean": "HÀNG"
+      }
+    ]
   },
   {
     "japanese": "にもつ",
@@ -277,7 +383,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "object",
-    "example": "荷物を送ります。"
+    "example": "荷物を送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "荷",
+        "mean": "HÀ, HẠ"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "かきとめ",
@@ -287,7 +403,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "service",
-    "example": "書留で送ります。"
+    "example": "書留で送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "留",
+        "mean": "LƯU"
+      }
+    ]
   },
   {
     "japanese": "いろ",
@@ -297,7 +423,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "noun",
-    "example": "きれいな色です。"
+    "example": "きれいな色です。",
+    "kanji_search_results": [
+      {
+        "kanji": "色",
+        "mean": "SẮC"
+      }
+    ]
   },
   {
     "japanese": "セーター",
@@ -327,7 +459,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を貸します。"
+    "example": "本を貸します。",
+    "kanji_search_results": [
+      {
+        "kanji": "貸",
+        "mean": "THẢI, THẮC"
+      }
+    ]
   },
   {
     "japanese": "あげます",
@@ -347,7 +485,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日本語を教えます。"
+    "example": "日本語を教えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "教",
+        "mean": "GIÁO, GIAO"
+      }
+    ]
   },
   {
     "japanese": "おくります",
@@ -357,7 +501,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "手紙を送ります。"
+    "example": "手紙を送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "送",
+        "mean": "TỐNG"
+      }
+    ]
   },
   {
     "japanese": "かけます",
@@ -367,7 +517,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "電話をかけます。"
+    "example": "電話をかけます。",
+    "kanji_search_results": [
+      {
+        "kanji": "賭",
+        "mean": "ĐỔ"
+      }
+    ]
   },
   {
     "japanese": "かります",
@@ -377,7 +533,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を借ります。"
+    "example": "本を借ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "借",
+        "mean": "TÁ"
+      }
+    ]
   },
   {
     "japanese": "ならいます",
@@ -387,7 +549,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ピアノを習います。"
+    "example": "ピアノを習います。",
+    "kanji_search_results": [
+      {
+        "kanji": "習",
+        "mean": "TẬP"
+      }
+    ]
   },
   {
     "japanese": "もらいます",
@@ -417,7 +585,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "友達と話します。"
+    "example": "友達と話します。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      }
+    ]
   },
   {
     "japanese": "すてき",
@@ -527,7 +701,21 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "number",
-    "example": "りんごを十買います。"
+    "example": "りんごを十買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "瓧",
+        "mean": ""
+      },
+      {
+        "kanji": "磅",
+        "mean": "BÀNG, BẢNG"
+      },
+      {
+        "kanji": "碼",
+        "mean": "MÃ"
+      }
+    ]
   },
   {
     "japanese": "いくつ",
@@ -547,7 +735,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "number",
-    "example": "車を一台買います。"
+    "example": "車を一台買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "台",
+        "mean": "THAI, ĐÀI, DI"
+      }
+    ]
   },
   {
     "japanese": "なんだい",
@@ -557,7 +751,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何台買いますか。"
+    "example": "何台買いますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "台",
+        "mean": "THAI, ĐÀI, DI"
+      }
+    ]
   },
   {
     "japanese": "－まい",
@@ -567,7 +771,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "number",
-    "example": "切手を一枚買います。"
+    "example": "切手を一枚買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "枚",
+        "mean": "MAI"
+      }
+    ]
   },
   {
     "japanese": "なんまい",
@@ -577,7 +787,17 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何枚買いますか。"
+    "example": "何枚買いますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "枚",
+        "mean": "MAI"
+      }
+    ]
   },
   {
     "japanese": "また",
@@ -597,7 +817,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "初めて日本に来ました。"
+    "example": "初めて日本に来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "初",
+        "mean": "SƠ"
+      }
+    ]
   },
   {
     "japanese": "～を おねがいします",
@@ -607,7 +833,13 @@
     "lesson": 10,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "コーヒーをお願いします。"
+    "example": "コーヒーをお願いします。",
+    "kanji_search_results": [
+      {
+        "kanji": "願",
+        "mean": "NGUYỆN"
+      }
+    ]
   },
   {
     "japanese": "いらっしゃいませ",

--- a/data/lesson_11_vocabulary.json
+++ b/data/lesson_11_vocabulary.json
@@ -170,12 +170,12 @@
     "example": "留学生です。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "留",
         "mean": "LƯU"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       },
       {
         "kanji": "生",
@@ -214,12 +214,12 @@
     "example": "経済学部です。",
     "kanji_search_results": [
       {
-        "kanji": "部",
-        "mean": "BỘ"
-      },
-      {
         "kanji": "学",
         "mean": "HỌC"
+      },
+      {
+        "kanji": "部",
+        "mean": "BỘ"
       }
     ]
   },
@@ -234,20 +234,20 @@
     "example": "経済学部で勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "部",
-        "mean": "BỘ"
-      },
-      {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "経",
         "mean": "KINH"
       },
       {
         "kanji": "済",
         "mean": "TẾ"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "部",
+        "mean": "BỘ"
       }
     ]
   },
@@ -312,12 +312,12 @@
     "example": "歴史を勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "史",
-        "mean": "SỬ"
-      },
-      {
         "kanji": "歴",
         "mean": "LỊCH"
+      },
+      {
+        "kanji": "史",
+        "mean": "SỬ"
       }
     ]
   },
@@ -574,16 +574,16 @@
     "example": "駐車場に車を止めます。",
     "kanji_search_results": [
       {
-        "kanji": "場",
-        "mean": "TRÀNG, TRƯỜNG"
-      },
-      {
         "kanji": "駐",
         "mean": "TRÚ"
       },
       {
         "kanji": "車",
         "mean": "XA"
+      },
+      {
+        "kanji": "場",
+        "mean": "TRÀNG, TRƯỜNG"
       }
     ]
   },
@@ -784,12 +784,12 @@
     "example": "大切な人です。",
     "kanji_search_results": [
       {
-        "kanji": "切",
-        "mean": "THIẾT, THẾ"
-      },
-      {
         "kanji": "大",
         "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
       }
     ]
   },
@@ -910,12 +910,12 @@
     "example": "九州に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "州",
-        "mean": "CHÂU"
-      },
-      {
         "kanji": "九",
         "mean": "CỬU, CƯU"
+      },
+      {
+        "kanji": "州",
+        "mean": "CHÂU"
       }
     ]
   },

--- a/data/lesson_11_vocabulary.json
+++ b/data/lesson_11_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "鼻が高いです。"
+    "example": "鼻が高いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "鼻",
+        "mean": "TỊ"
+      }
+    ]
   },
   {
     "japanese": "め",
@@ -17,7 +23,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "目が大きいです。"
+    "example": "目が大きいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "目",
+        "mean": "MỤC"
+      }
+    ]
   },
   {
     "japanese": "くび",
@@ -27,7 +39,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "首が長いです。"
+    "example": "首が長いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "首",
+        "mean": "THỦ, THÚ"
+      }
+    ]
   },
   {
     "japanese": "あし",
@@ -37,7 +55,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "足が速いです。"
+    "example": "足が速いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "足",
+        "mean": "TÚC"
+      }
+    ]
   },
   {
     "japanese": "みみ",
@@ -47,7 +71,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "耳が聞こえません。"
+    "example": "耳が聞こえません。",
+    "kanji_search_results": [
+      {
+        "kanji": "耳",
+        "mean": "NHĨ"
+      }
+    ]
   },
   {
     "japanese": "せ",
@@ -57,7 +87,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "背が高いです。"
+    "example": "背が高いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "背",
+        "mean": "BỐI, BỘI"
+      }
+    ]
   },
   {
     "japanese": "あたま",
@@ -67,7 +103,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "頭が痛いです。"
+    "example": "頭が痛いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "頭",
+        "mean": "ĐẦU"
+      }
+    ]
   },
   {
     "japanese": "かお",
@@ -77,7 +119,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "顔がきれいです。"
+    "example": "顔がきれいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "顔",
+        "mean": "NHAN"
+      }
+    ]
   },
   {
     "japanese": "くち",
@@ -87,7 +135,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "口が大きいです。"
+    "example": "口が大きいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      }
+    ]
   },
   {
     "japanese": "からだ",
@@ -97,7 +151,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "body",
-    "example": "体が丈夫です。"
+    "example": "体が丈夫です。",
+    "kanji_search_results": [
+      {
+        "kanji": "体",
+        "mean": "THỂ"
+      }
+    ]
   },
   {
     "japanese": "りゅうがくせい",
@@ -107,7 +167,21 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "person",
-    "example": "留学生です。"
+    "example": "留学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "留",
+        "mean": "LƯU"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "けいざい",
@@ -117,7 +191,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "経済を勉強します。"
+    "example": "経済を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "経",
+        "mean": "KINH"
+      },
+      {
+        "kanji": "済",
+        "mean": "TẾ"
+      }
+    ]
   },
   {
     "japanese": "がくぶ",
@@ -127,7 +211,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "経済学部です。"
+    "example": "経済学部です。",
+    "kanji_search_results": [
+      {
+        "kanji": "部",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      }
+    ]
   },
   {
     "japanese": "けいざいがくぶ",
@@ -137,7 +231,25 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "経済学部で勉強します。"
+    "example": "経済学部で勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "部",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "経",
+        "mean": "KINH"
+      },
+      {
+        "kanji": "済",
+        "mean": "TẾ"
+      }
+    ]
   },
   {
     "japanese": "かんきょう",
@@ -147,7 +259,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "環境を守ります。"
+    "example": "環境を守ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "環",
+        "mean": "HOÀN"
+      },
+      {
+        "kanji": "境",
+        "mean": "CẢNH"
+      }
+    ]
   },
   {
     "japanese": "がくひ",
@@ -157,7 +279,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "学費が高いです。"
+    "example": "学費が高いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "費",
+        "mean": "PHÍ, BỈ"
+      }
+    ]
   },
   {
     "japanese": "キャンパス",
@@ -177,7 +309,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "education",
-    "example": "歴史を勉強します。"
+    "example": "歴史を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "史",
+        "mean": "SỬ"
+      },
+      {
+        "kanji": "歴",
+        "mean": "LỊCH"
+      }
+    ]
   },
   {
     "japanese": "しごと",
@@ -187,7 +329,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "work",
-    "example": "仕事が忙しいです。"
+    "example": "仕事が忙しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "仕",
+        "mean": "SĨ"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "てんぷら",
@@ -197,7 +349,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "food",
-    "example": "天ぷらを食べます。"
+    "example": "天ぷらを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "天",
+        "mean": "THIÊN"
+      }
+    ]
   },
   {
     "japanese": "とんカツ",
@@ -207,7 +365,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "food",
-    "example": "豚カツを食べます。"
+    "example": "豚カツを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "豚",
+        "mean": "ĐỒN, ĐỘN"
+      }
+    ]
   },
   {
     "japanese": "のみもの",
@@ -217,7 +381,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "food",
-    "example": "飲み物を注文します。"
+    "example": "飲み物を注文します。",
+    "kanji_search_results": [
+      {
+        "kanji": "飲",
+        "mean": "ẨM, ẤM"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "いちご",
@@ -257,7 +431,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "sport",
-    "example": "柔道をします。"
+    "example": "柔道をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "柔",
+        "mean": "NHU"
+      },
+      {
+        "kanji": "道",
+        "mean": "ĐẠO, ĐÁO"
+      }
+    ]
   },
   {
     "japanese": "スケート",
@@ -277,7 +461,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "一年間勉強します。"
+    "example": "一年間勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "はる",
@@ -287,7 +477,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "春が好きです。"
+    "example": "春が好きです。",
+    "kanji_search_results": [
+      {
+        "kanji": "春",
+        "mean": "XUÂN"
+      }
+    ]
   },
   {
     "japanese": "なつ",
@@ -297,7 +493,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "夏は暑いです。"
+    "example": "夏は暑いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "夏",
+        "mean": "HẠ, GIẠ, GIÁ"
+      }
+    ]
   },
   {
     "japanese": "あき",
@@ -307,7 +509,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "秋は涼しいです。"
+    "example": "秋は涼しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "秋",
+        "mean": "THU"
+      }
+    ]
   },
   {
     "japanese": "ふゆ",
@@ -317,7 +525,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "冬は寒いです。"
+    "example": "冬は寒いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "冬",
+        "mean": "ĐÔNG"
+      }
+    ]
   },
   {
     "japanese": "どくしん",
@@ -327,7 +541,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "person",
-    "example": "独身です。"
+    "example": "独身です。",
+    "kanji_search_results": [
+      {
+        "kanji": "独",
+        "mean": "ĐỘC"
+      },
+      {
+        "kanji": "身",
+        "mean": "THÂN, QUYÊN"
+      }
+    ]
   },
   {
     "japanese": "マンション",
@@ -347,7 +571,21 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "place",
-    "example": "駐車場に車を止めます。"
+    "example": "駐車場に車を止めます。",
+    "kanji_search_results": [
+      {
+        "kanji": "場",
+        "mean": "TRÀNG, TRƯỜNG"
+      },
+      {
+        "kanji": "駐",
+        "mean": "TRÚ"
+      },
+      {
+        "kanji": "車",
+        "mean": "XA"
+      }
+    ]
   },
   {
     "japanese": "おおい",
@@ -357,7 +595,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "人が多いです。"
+    "example": "人が多いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "多",
+        "mean": "ĐA"
+      }
+    ]
   },
   {
     "japanese": "すくない",
@@ -367,7 +611,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "人が少ないです。"
+    "example": "人が少ないです。",
+    "kanji_search_results": [
+      {
+        "kanji": "少",
+        "mean": "THIỂU, THIẾU"
+      }
+    ]
   },
   {
     "japanese": "ながい",
@@ -377,7 +627,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "髪が長いです。"
+    "example": "髪が長いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "長",
+        "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "みじかい",
@@ -387,7 +643,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "髪が短いです。"
+    "example": "髪が短いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "短",
+        "mean": "ĐOẢN"
+      }
+    ]
   },
   {
     "japanese": "あたたかい",
@@ -397,7 +659,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "今日は暖かいです。"
+    "example": "今日は暖かいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "暖",
+        "mean": "NOÃN"
+      }
+    ]
   },
   {
     "japanese": "すずしい",
@@ -407,7 +675,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "今日は涼しいです。"
+    "example": "今日は涼しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "涼",
+        "mean": "LƯƠNG, LƯỢNG"
+      }
+    ]
   },
   {
     "japanese": "あかるい",
@@ -417,7 +691,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "部屋が明るいです。"
+    "example": "部屋が明るいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "明",
+        "mean": "MINH"
+      }
+    ]
   },
   {
     "japanese": "くらい",
@@ -427,7 +707,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "部屋が暗いです。"
+    "example": "部屋が暗いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "暗",
+        "mean": "ÁM"
+      }
+    ]
   },
   {
     "japanese": "やさしい",
@@ -437,7 +723,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "優しい人です。"
+    "example": "優しい人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "優",
+        "mean": "ƯU"
+      }
+    ]
   },
   {
     "japanese": "はやい",
@@ -447,7 +739,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "車が速いです。"
+    "example": "車が速いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "速",
+        "mean": "TỐC"
+      }
+    ]
   },
   {
     "japanese": "おそい",
@@ -457,7 +755,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "電車が遅いです。"
+    "example": "電車が遅いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "遅",
+        "mean": "TRÌ"
+      }
+    ]
   },
   {
     "japanese": "うるさい",
@@ -477,7 +781,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "大切な人です。"
+    "example": "大切な人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   },
   {
     "japanese": "まじめ",
@@ -497,7 +811,13 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三年間勉強します。"
+    "example": "三年間勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "なんねん",
@@ -507,7 +827,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何年勉強しますか。"
+    "example": "何年勉強しますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "－へいほうメートル",
@@ -517,7 +847,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "measurement",
-    "example": "30平方メートルです。"
+    "example": "30平方メートルです。",
+    "kanji_search_results": [
+      {
+        "kanji": "平",
+        "mean": "BÌNH, BIỀN"
+      },
+      {
+        "kanji": "方",
+        "mean": "PHƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "どちら",
@@ -567,7 +907,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "place",
-    "example": "九州に行きます。"
+    "example": "九州に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "州",
+        "mean": "CHÂU"
+      },
+      {
+        "kanji": "九",
+        "mean": "CỬU, CƯU"
+      }
+    ]
   },
   {
     "japanese": "マニラ",
@@ -597,7 +947,17 @@
     "lesson": 11,
     "difficulty": "beginner",
     "category": "place",
-    "example": "奈良で鹿を見ます。"
+    "example": "奈良で鹿を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "奈",
+        "mean": "NẠI"
+      },
+      {
+        "kanji": "良",
+        "mean": "LƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "ソウル",

--- a/data/lesson_12_vocabulary.json
+++ b/data/lesson_12_vocabulary.json
@@ -76,12 +76,12 @@
     "example": "準備をします。",
     "kanji_search_results": [
       {
-        "kanji": "備",
-        "mean": "BỊ"
-      },
-      {
         "kanji": "準",
         "mean": "CHUẨN, CHUYẾT"
+      },
+      {
+        "kanji": "備",
+        "mean": "BỊ"
       }
     ]
   },
@@ -96,12 +96,12 @@
     "example": "授業を受けます。",
     "kanji_search_results": [
       {
-        "kanji": "業",
-        "mean": "NGHIỆP"
-      },
-      {
         "kanji": "授",
         "mean": "THỤ"
+      },
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
       }
     ]
   },
@@ -228,12 +228,12 @@
     "example": "黄色い車です。",
     "kanji_search_results": [
       {
-        "kanji": "色",
-        "mean": "SẮC"
-      },
-      {
         "kanji": "黄",
         "mean": "HOÀNG"
+      },
+      {
+        "kanji": "色",
+        "mean": "SẮC"
       }
     ]
   },
@@ -526,12 +526,12 @@
     "example": "三時間かかります。",
     "kanji_search_results": [
       {
-        "kanji": "間",
-        "mean": "GIAN"
-      },
-      {
         "kanji": "時",
         "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
       }
     ]
   },
@@ -550,12 +550,12 @@
         "mean": "HÀ"
       },
       {
-        "kanji": "間",
-        "mean": "GIAN"
-      },
-      {
         "kanji": "時",
         "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
       }
     ]
   },
@@ -722,12 +722,12 @@
     "example": "半年かかります。",
     "kanji_search_results": [
       {
-        "kanji": "年",
-        "mean": "NIÊN"
-      },
-      {
         "kanji": "半",
         "mean": "BÁN"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
       }
     ]
   },
@@ -856,12 +856,12 @@
         "mean": "LỘC"
       },
       {
-        "kanji": "島",
-        "mean": "ĐẢO"
-      },
-      {
         "kanji": "児",
         "mean": "NHI"
+      },
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
       }
     ]
   },
@@ -896,12 +896,12 @@
     "example": "宮島を見学します。",
     "kanji_search_results": [
       {
-        "kanji": "島",
-        "mean": "ĐẢO"
-      },
-      {
         "kanji": "宮",
         "mean": "CUNG"
+      },
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
       }
     ]
   }

--- a/data/lesson_12_vocabulary.json
+++ b/data/lesson_12_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "休みを取ります。"
+    "example": "休みを取ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "休",
+        "mean": "HƯU"
+      }
+    ]
   },
   {
     "japanese": "ひるやすみ",
@@ -17,7 +23,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "昼休みに昼ご飯を食べます。"
+    "example": "昼休みに昼ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "昼",
+        "mean": "TRÚ"
+      },
+      {
+        "kanji": "休",
+        "mean": "HƯU"
+      }
+    ]
   },
   {
     "japanese": "はなみ",
@@ -27,7 +43,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "花見をします。"
+    "example": "花見をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "花",
+        "mean": "HOA"
+      },
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "おにぎり",
@@ -47,7 +73,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "準備をします。"
+    "example": "準備をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "備",
+        "mean": "BỊ"
+      },
+      {
+        "kanji": "準",
+        "mean": "CHUẨN, CHUYẾT"
+      }
+    ]
   },
   {
     "japanese": "じゅぎょう",
@@ -57,7 +93,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "education",
-    "example": "授業を受けます。"
+    "example": "授業を受けます。",
+    "kanji_search_results": [
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
+      },
+      {
+        "kanji": "授",
+        "mean": "THỤ"
+      }
+    ]
   },
   {
     "japanese": "きもの",
@@ -67,7 +113,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "clothing",
-    "example": "着物を着ます。"
+    "example": "着物を着ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "着",
+        "mean": "TRỨ, TRƯỚC, TRỮ"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "ホテル",
@@ -97,7 +153,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "空港で待ちます。"
+    "example": "空港で待ちます。",
+    "kanji_search_results": [
+      {
+        "kanji": "空",
+        "mean": "KHÔNG, KHỐNG, KHỔNG"
+      },
+      {
+        "kanji": "港",
+        "mean": "CẢNG"
+      }
+    ]
   },
   {
     "japanese": "～たち",
@@ -127,7 +193,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "橋を渡ります。"
+    "example": "橋を渡ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "橋",
+        "mean": "KIỀU, KHIÊU, CAO"
+      }
+    ]
   },
   {
     "japanese": "あか",
@@ -137,7 +209,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "color",
-    "example": "赤い花です。"
+    "example": "赤い花です。",
+    "kanji_search_results": [
+      {
+        "kanji": "赤",
+        "mean": "XÍCH, THÍCH"
+      }
+    ]
   },
   {
     "japanese": "きいろ",
@@ -147,7 +225,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "color",
-    "example": "黄色い車です。"
+    "example": "黄色い車です。",
+    "kanji_search_results": [
+      {
+        "kanji": "色",
+        "mean": "SẮC"
+      },
+      {
+        "kanji": "黄",
+        "mean": "HOÀNG"
+      }
+    ]
   },
   {
     "japanese": "けしき",
@@ -157,7 +245,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "きれいな景色です。"
+    "example": "きれいな景色です。",
+    "kanji_search_results": [
+      {
+        "kanji": "景",
+        "mean": "CẢNH"
+      },
+      {
+        "kanji": "色",
+        "mean": "SẮC"
+      }
+    ]
   },
   {
     "japanese": "しま",
@@ -167,7 +265,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "島に行きます。"
+    "example": "島に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
+      }
+    ]
   },
   {
     "japanese": "はっぴょうします",
@@ -177,7 +281,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "研究を発表します。"
+    "example": "研究を発表します。",
+    "kanji_search_results": [
+      {
+        "kanji": "発",
+        "mean": "PHÁT"
+      },
+      {
+        "kanji": "表",
+        "mean": "BIỂU"
+      }
+    ]
   },
   {
     "japanese": "のぼります",
@@ -187,7 +301,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "山に登ります。"
+    "example": "山に登ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
+      }
+    ]
   },
   {
     "japanese": "とまります",
@@ -197,7 +317,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ホテルに泊まります。"
+    "example": "ホテルに泊まります。",
+    "kanji_search_results": [
+      {
+        "kanji": "泊",
+        "mean": "BẠC, PHÁCH"
+      }
+    ]
   },
   {
     "japanese": "きます",
@@ -207,7 +333,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "服を着ます。"
+    "example": "服を着ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "着",
+        "mean": "TRỨ, TRƯỚC, TRỮ"
+      }
+    ]
   },
   {
     "japanese": "ぬぎます",
@@ -217,7 +349,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "靴を脱ぎます。"
+    "example": "靴を脱ぎます。",
+    "kanji_search_results": [
+      {
+        "kanji": "脱",
+        "mean": "THOÁT, ĐOÁI"
+      }
+    ]
   },
   {
     "japanese": "かかります",
@@ -237,7 +375,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "写真を撮ります。"
+    "example": "写真を撮ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "撮",
+        "mean": "TOÁT"
+      }
+    ]
   },
   {
     "japanese": "きびしい",
@@ -247,7 +391,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "厳しい先生です。"
+    "example": "厳しい先生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "厳",
+        "mean": "NGHIÊM"
+      }
+    ]
   },
   {
     "japanese": "こわい",
@@ -257,7 +407,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "怖い映画です。"
+    "example": "怖い映画です。",
+    "kanji_search_results": [
+      {
+        "kanji": "怖",
+        "mean": "PHỐ, BỐ"
+      }
+    ]
   },
   {
     "japanese": "おもい",
@@ -267,7 +423,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "重い荷物です。"
+    "example": "重い荷物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "重",
+        "mean": "TRỌNG, TRÙNG"
+      }
+    ]
   },
   {
     "japanese": "かるい",
@@ -277,7 +439,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "軽い荷物です。"
+    "example": "軽い荷物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "軽",
+        "mean": "KHINH"
+      }
+    ]
   },
   {
     "japanese": "つめたい",
@@ -287,7 +455,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "冷たい水です。"
+    "example": "冷たい水です。",
+    "kanji_search_results": [
+      {
+        "kanji": "冷",
+        "mean": "LÃNH"
+      }
+    ]
   },
   {
     "japanese": "－ふん",
@@ -297,7 +471,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三十分かかります。"
+    "example": "三十分かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "－ぷん",
@@ -307,7 +487,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "五分かかります。"
+    "example": "五分かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "なんぷん",
@@ -317,7 +503,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何分かかりますか。"
+    "example": "何分かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "－じかん",
@@ -327,7 +523,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三時間かかります。"
+    "example": "三時間かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "なんじかん",
@@ -337,7 +543,21 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何時間かかりますか。"
+    "example": "何時間かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "－にち",
@@ -347,7 +567,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三日かかります。"
+    "example": "三日かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "なんにち",
@@ -357,7 +583,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何日かかりますか。"
+    "example": "何日かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "－しゅうかん",
@@ -367,7 +603,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "二週間かかります。"
+    "example": "二週間かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      }
+    ]
   },
   {
     "japanese": "なんしゅうかん",
@@ -377,7 +623,21 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何週間かかりますか。"
+    "example": "何週間かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      }
+    ]
   },
   {
     "japanese": "－かげつ",
@@ -387,7 +647,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三か月かかります。"
+    "example": "三か月かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "なんかげつ",
@@ -397,7 +663,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何か月かかりますか。"
+    "example": "何か月かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "－ねん",
@@ -407,7 +683,13 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "一年かかります。"
+    "example": "一年かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "なんねん",
@@ -417,7 +699,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何年かかりますか。"
+    "example": "何年かかりますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "はんとし",
@@ -427,7 +719,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "time",
-    "example": "半年かかります。"
+    "example": "半年かかります。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      },
+      {
+        "kanji": "半",
+        "mean": "BÁN"
+      }
+    ]
   },
   {
     "japanese": "どのぐらい",
@@ -527,7 +829,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "福岡に行きます。"
+    "example": "福岡に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "福",
+        "mean": "PHÚC"
+      },
+      {
+        "kanji": "岡",
+        "mean": "CƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "かごしま",
@@ -537,7 +849,21 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "鹿児島に行きます。"
+    "example": "鹿児島に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "鹿",
+        "mean": "LỘC"
+      },
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
+      },
+      {
+        "kanji": "児",
+        "mean": "NHI"
+      }
+    ]
   },
   {
     "japanese": "なりた",
@@ -547,7 +873,17 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "成田空港に行きます。"
+    "example": "成田空港に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "成",
+        "mean": "THÀNH"
+      },
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
+      }
+    ]
   },
   {
     "japanese": "みやじま",
@@ -557,6 +893,16 @@
     "lesson": 12,
     "difficulty": "beginner",
     "category": "place",
-    "example": "宮島を見学します。"
+    "example": "宮島を見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
+      },
+      {
+        "kanji": "宮",
+        "mean": "CUNG"
+      }
+    ]
   }
 ]

--- a/data/lesson_13_vocabulary.json
+++ b/data/lesson_13_vocabulary.json
@@ -66,16 +66,16 @@
     "example": "市役所に行きます。",
     "kanji_search_results": [
       {
+        "kanji": "市",
+        "mean": "THỊ"
+      },
+      {
         "kanji": "役",
         "mean": "DỊCH"
       },
       {
         "kanji": "所",
         "mean": "SỞ"
-      },
-      {
-        "kanji": "市",
-        "mean": "THỊ"
       }
     ]
   },
@@ -130,12 +130,12 @@
     "example": "工場を見学します。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "見",
         "mean": "KIẾN, HIỆN"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       }
     ]
   },
@@ -150,14 +150,6 @@
     "example": "外国人登録をします。",
     "kanji_search_results": [
       {
-        "kanji": "録",
-        "mean": "LỤC"
-      },
-      {
-        "kanji": "登",
-        "mean": "ĐĂNG"
-      },
-      {
         "kanji": "外",
         "mean": "NGOẠI"
       },
@@ -168,6 +160,14 @@
       {
         "kanji": "人",
         "mean": "NHÂN"
+      },
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
+      },
+      {
+        "kanji": "録",
+        "mean": "LỤC"
       }
     ]
   },
@@ -228,12 +228,12 @@
     "example": "相撲を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "撲",
-        "mean": "PHÁC, BẠC, PHỐC"
-      },
-      {
         "kanji": "相",
         "mean": "TƯƠNG, TƯỚNG"
+      },
+      {
+        "kanji": "撲",
+        "mean": "PHÁC, BẠC, PHỐC"
       }
     ]
   },
@@ -258,16 +258,16 @@
     "example": "大学院で勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "院",
-        "mean": "VIỆN"
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
       },
       {
         "kanji": "学",
         "mean": "HỌC"
       },
       {
-        "kanji": "大",
-        "mean": "ĐẠI, THÁI"
+        "kanji": "院",
+        "mean": "VIỆN"
       }
     ]
   },
@@ -416,12 +416,12 @@
     "example": "家事を手伝います。",
     "kanji_search_results": [
       {
-        "kanji": "伝",
-        "mean": "TRUYỀN"
-      },
-      {
         "kanji": "手",
         "mean": "THỦ"
+      },
+      {
+        "kanji": "伝",
+        "mean": "TRUYỀN"
       }
     ]
   },
@@ -504,12 +504,12 @@
         "mean": "ĐẠI, THÁI"
       },
       {
-        "kanji": "夫",
-        "mean": "PHU, PHÙ"
-      },
-      {
         "kanji": "丈",
         "mean": "TRƯỢNG"
+      },
+      {
+        "kanji": "夫",
+        "mean": "PHU, PHÙ"
       }
     ]
   },
@@ -570,12 +570,12 @@
     "example": "頑張ってください。",
     "kanji_search_results": [
       {
-        "kanji": "張",
-        "mean": "TRƯƠNG, TRƯỚNG"
-      },
-      {
         "kanji": "頑",
         "mean": "NGOAN"
+      },
+      {
+        "kanji": "張",
+        "mean": "TRƯƠNG, TRƯỚNG"
       }
     ]
   },
@@ -642,20 +642,20 @@
     "example": "歌舞伎座で歌舞伎を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "伎",
-        "mean": "KĨ"
-      },
-      {
-        "kanji": "座",
-        "mean": "TỌA"
-      },
-      {
         "kanji": "歌",
         "mean": "CA"
       },
       {
         "kanji": "舞",
         "mean": "VŨ"
+      },
+      {
+        "kanji": "伎",
+        "mean": "KĨ"
+      },
+      {
+        "kanji": "座",
+        "mean": "TỌA"
       }
     ]
   },

--- a/data/lesson_13_vocabulary.json
+++ b/data/lesson_13_vocabulary.json
@@ -7,7 +7,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "object",
-    "example": "布団で寝ます。"
+    "example": "布団で寝ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "布",
+        "mean": "BỐ"
+      },
+      {
+        "kanji": "団",
+        "mean": "ĐOÀN"
+      }
+    ]
   },
   {
     "japanese": "さら",
@@ -17,7 +27,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "object",
-    "example": "皿を洗います。"
+    "example": "皿を洗います。",
+    "kanji_search_results": [
+      {
+        "kanji": "皿",
+        "mean": "MÃNH"
+      }
+    ]
   },
   {
     "japanese": "コップ",
@@ -47,7 +63,21 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "place",
-    "example": "市役所に行きます。"
+    "example": "市役所に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "役",
+        "mean": "DỊCH"
+      },
+      {
+        "kanji": "所",
+        "mean": "SỞ"
+      },
+      {
+        "kanji": "市",
+        "mean": "THỊ"
+      }
+    ]
   },
   {
     "japanese": "しちょう",
@@ -57,7 +87,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "person",
-    "example": "市長に会います。"
+    "example": "市長に会います。",
+    "kanji_search_results": [
+      {
+        "kanji": "市",
+        "mean": "THỊ"
+      },
+      {
+        "kanji": "長",
+        "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "こうじょう",
@@ -67,7 +107,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "place",
-    "example": "工場を見学します。"
+    "example": "工場を見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "工",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "場",
+        "mean": "TRÀNG, TRƯỜNG"
+      }
+    ]
   },
   {
     "japanese": "けんがく",
@@ -77,7 +127,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "工場を見学します。"
+    "example": "工場を見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "がいこくじんとうろく",
@@ -87,7 +147,29 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "外国人登録をします。"
+    "example": "外国人登録をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "録",
+        "mean": "LỤC"
+      },
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
+      },
+      {
+        "kanji": "外",
+        "mean": "NGOẠI"
+      },
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "スキー",
@@ -107,7 +189,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "noun",
-    "example": "作り方を教えます。"
+    "example": "作り方を教えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "方",
+        "mean": "PHƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "つくりかた",
@@ -117,7 +205,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "noun",
-    "example": "料理の作り方を覚えます。"
+    "example": "料理の作り方を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "作",
+        "mean": "TÁC"
+      },
+      {
+        "kanji": "方",
+        "mean": "PHƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "すもう",
@@ -127,7 +225,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "sport",
-    "example": "相撲を見ます。"
+    "example": "相撲を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "撲",
+        "mean": "PHÁC, BẠC, PHỐC"
+      },
+      {
+        "kanji": "相",
+        "mean": "TƯƠNG, TƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "チケット",
@@ -147,7 +255,21 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "education",
-    "example": "大学院で勉強します。"
+    "example": "大学院で勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "院",
+        "mean": "VIỆN"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   },
   {
     "japanese": "ロボット",
@@ -167,7 +289,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "education",
-    "example": "工学を勉強します。"
+    "example": "工学を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "工",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      }
+    ]
   },
   {
     "japanese": "ロボットこうがく",
@@ -177,7 +309,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "education",
-    "example": "ロボット工学を勉強します。"
+    "example": "ロボット工学を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "工",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      }
+    ]
   },
   {
     "japanese": "しょうらい",
@@ -187,7 +329,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "time",
-    "example": "将来の夢を話します。"
+    "example": "将来の夢を話します。",
+    "kanji_search_results": [
+      {
+        "kanji": "将",
+        "mean": "TƯƠNG, THƯƠNG, TƯỚNG"
+      },
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      }
+    ]
   },
   {
     "japanese": "あそびます",
@@ -197,7 +349,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "友達と遊びます。"
+    "example": "友達と遊びます。",
+    "kanji_search_results": [
+      {
+        "kanji": "遊",
+        "mean": "DU"
+      }
+    ]
   },
   {
     "japanese": "かえします",
@@ -207,7 +365,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を返します。"
+    "example": "本を返します。",
+    "kanji_search_results": [
+      {
+        "kanji": "返",
+        "mean": "PHẢN"
+      }
+    ]
   },
   {
     "japanese": "むかえます",
@@ -217,7 +381,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "空港で迎えます。"
+    "example": "空港で迎えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "迎",
+        "mean": "NGHÊNH, NGHỊNH"
+      }
+    ]
   },
   {
     "japanese": "もちます",
@@ -227,7 +397,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "荷物を持ちます。"
+    "example": "荷物を持ちます。",
+    "kanji_search_results": [
+      {
+        "kanji": "持",
+        "mean": "TRÌ"
+      }
+    ]
   },
   {
     "japanese": "てつだいます",
@@ -237,7 +413,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "家事を手伝います。"
+    "example": "家事を手伝います。",
+    "kanji_search_results": [
+      {
+        "kanji": "伝",
+        "mean": "TRUYỀN"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "あらいます",
@@ -247,7 +433,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "皿を洗います。"
+    "example": "皿を洗います。",
+    "kanji_search_results": [
+      {
+        "kanji": "洗",
+        "mean": "TẨY, TIỂN"
+      }
+    ]
   },
   {
     "japanese": "つかいます",
@@ -257,7 +449,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "コンピューターを使います。"
+    "example": "コンピューターを使います。",
+    "kanji_search_results": [
+      {
+        "kanji": "使",
+        "mean": "SỬ, SỨ"
+      }
+    ]
   },
   {
     "japanese": "ほしい",
@@ -267,7 +465,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "新しい車が欲しいです。"
+    "example": "新しい車が欲しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "欲",
+        "mean": "DỤC"
+      }
+    ]
   },
   {
     "japanese": "いたい",
@@ -277,7 +481,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "頭が痛いです。"
+    "example": "頭が痛いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "痛",
+        "mean": "THỐNG"
+      }
+    ]
   },
   {
     "japanese": "だいじょうぶ",
@@ -287,7 +497,21 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "大丈夫です。"
+    "example": "大丈夫です。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "夫",
+        "mean": "PHU, PHÙ"
+      },
+      {
+        "kanji": "丈",
+        "mean": "TRƯỢNG"
+      }
+    ]
   },
   {
     "japanese": "－ねんせい",
@@ -297,7 +521,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "education",
-    "example": "一年生です。"
+    "example": "一年生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "－まえに",
@@ -307,7 +541,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三年前に日本に来ました。"
+    "example": "三年前に日本に来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      }
+    ]
   },
   {
     "japanese": "ありがとう ございます",
@@ -327,7 +567,17 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "頑張ってください。"
+    "example": "頑張ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "張",
+        "mean": "TRƯƠNG, TRƯỚNG"
+      },
+      {
+        "kanji": "頑",
+        "mean": "NGOAN"
+      }
+    ]
   },
   {
     "japanese": "どう しますか",
@@ -347,7 +597,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "疲れました。"
+    "example": "疲れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "疲",
+        "mean": "BÌ"
+      }
+    ]
   },
   {
     "japanese": "のどが かわきました",
@@ -357,7 +613,13 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "のどが渇きました。"
+    "example": "のどが渇きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "渇",
+        "mean": "KHÁT"
+      }
+    ]
   },
   {
     "japanese": "おなかが すきました",
@@ -377,7 +639,25 @@
     "lesson": 13,
     "difficulty": "beginner",
     "category": "place",
-    "example": "歌舞伎座で歌舞伎を見ます。"
+    "example": "歌舞伎座で歌舞伎を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "伎",
+        "mean": "KĨ"
+      },
+      {
+        "kanji": "座",
+        "mean": "TỌA"
+      },
+      {
+        "kanji": "歌",
+        "mean": "CA"
+      },
+      {
+        "kanji": "舞",
+        "mean": "VŨ"
+      }
+    ]
   },
   {
     "japanese": "ただいま",

--- a/data/lesson_14_vocabulary.json
+++ b/data/lesson_14_vocabulary.json
@@ -72,12 +72,12 @@
     "example": "料金を払います。",
     "kanji_search_results": [
       {
-        "kanji": "金",
-        "mean": "KIM"
-      },
-      {
         "kanji": "料",
         "mean": "LIÊU, LIỆU"
+      },
+      {
+        "kanji": "金",
+        "mean": "KIM"
       }
     ]
   },
@@ -92,20 +92,20 @@
     "example": "電話料金が高いです。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
         "kanji": "電",
         "mean": "ĐIỆN"
       },
       {
-        "kanji": "金",
-        "mean": "KIM"
+        "kanji": "話",
+        "mean": "THOẠI"
       },
       {
         "kanji": "料",
         "mean": "LIÊU, LIỆU"
+      },
+      {
+        "kanji": "金",
+        "mean": "KIM"
       }
     ]
   },
@@ -120,12 +120,12 @@
     "example": "生け花を習います。",
     "kanji_search_results": [
       {
-        "kanji": "花",
-        "mean": "HOA"
-      },
-      {
         "kanji": "生",
         "mean": "SANH, SINH"
+      },
+      {
+        "kanji": "花",
+        "mean": "HOA"
       }
     ]
   },
@@ -220,20 +220,20 @@
     "example": "目覚まし時計をセットします。",
     "kanji_search_results": [
       {
-        "kanji": "覚",
-        "mean": "GIÁC"
+        "kanji": "目",
+        "mean": "MỤC"
       },
       {
-        "kanji": "計",
-        "mean": "KẾ, KÊ"
+        "kanji": "覚",
+        "mean": "GIÁC"
       },
       {
         "kanji": "時",
         "mean": "THÌ, THỜI"
       },
       {
-        "kanji": "目",
-        "mean": "MỤC"
+        "kanji": "計",
+        "mean": "KẾ, KÊ"
       }
     ]
   },
@@ -662,12 +662,12 @@
     "example": "自分で作ります。",
     "kanji_search_results": [
       {
-        "kanji": "分",
-        "mean": "PHÂN, PHẬN"
-      },
-      {
         "kanji": "自",
         "mean": "TỰ"
+      },
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
       }
     ]
   },
@@ -742,12 +742,12 @@
     "example": "長野でスキーをします。",
     "kanji_search_results": [
       {
-        "kanji": "野",
-        "mean": "DÃ"
-      },
-      {
         "kanji": "長",
         "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      },
+      {
+        "kanji": "野",
+        "mean": "DÃ"
       }
     ]
   },
@@ -762,12 +762,12 @@
     "example": "三重県に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "重",
-        "mean": "TRỌNG, TRÙNG"
-      },
-      {
         "kanji": "三",
         "mean": "TAM, TÁM"
+      },
+      {
+        "kanji": "重",
+        "mean": "TRỌNG, TRÙNG"
       }
     ]
   },
@@ -786,12 +786,12 @@
         "mean": "NHẪN"
       },
       {
-        "kanji": "村",
-        "mean": "THÔN"
-      },
-      {
         "kanji": "者",
         "mean": "GIẢ"
+      },
+      {
+        "kanji": "村",
+        "mean": "THÔN"
       }
     ]
   },
@@ -806,12 +806,12 @@
     "example": "文化センターで勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "化",
-        "mean": "HÓA"
-      },
-      {
         "kanji": "文",
         "mean": "VĂN, VẤN"
+      },
+      {
+        "kanji": "化",
+        "mean": "HÓA"
       }
     ]
   },
@@ -842,16 +842,16 @@
     "example": "辞書形を覚えます。",
     "kanji_search_results": [
       {
-        "kanji": "形",
-        "mean": "HÌNH"
+        "kanji": "辞",
+        "mean": "TỪ"
       },
       {
         "kanji": "書",
         "mean": "THƯ"
       },
       {
-        "kanji": "辞",
-        "mean": "TỪ"
+        "kanji": "形",
+        "mean": "HÌNH"
       }
     ]
   }

--- a/data/lesson_14_vocabulary.json
+++ b/data/lesson_14_vocabulary.json
@@ -17,7 +17,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "object",
-    "example": "畳の上で座ります。"
+    "example": "畳の上で座ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "畳",
+        "mean": "ĐIỆP"
+      }
+    ]
   },
   {
     "japanese": "かれ",
@@ -27,7 +33,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "person",
-    "example": "彼は学生です。"
+    "example": "彼は学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "彼",
+        "mean": "BỈ"
+      }
+    ]
   },
   {
     "japanese": "かのじょ",
@@ -37,7 +49,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "person",
-    "example": "彼女は教師です。"
+    "example": "彼女は教師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "彼",
+        "mean": "BỈ"
+      },
+      {
+        "kanji": "女",
+        "mean": "NỮ, NỨ, NHỮ"
+      }
+    ]
   },
   {
     "japanese": "りょうきん",
@@ -47,7 +69,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "money",
-    "example": "料金を払います。"
+    "example": "料金を払います。",
+    "kanji_search_results": [
+      {
+        "kanji": "金",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "料",
+        "mean": "LIÊU, LIỆU"
+      }
+    ]
   },
   {
     "japanese": "でんわりょうきん",
@@ -57,7 +89,25 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "money",
-    "example": "電話料金が高いです。"
+    "example": "電話料金が高いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "金",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "料",
+        "mean": "LIÊU, LIỆU"
+      }
+    ]
   },
   {
     "japanese": "いけばな",
@@ -67,7 +117,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "art",
-    "example": "生け花を習います。"
+    "example": "生け花を習います。",
+    "kanji_search_results": [
+      {
+        "kanji": "花",
+        "mean": "HOA"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "にんじゃ",
@@ -77,7 +137,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "person",
-    "example": "忍者について勉強します。"
+    "example": "忍者について勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "忍",
+        "mean": "NHẪN"
+      },
+      {
+        "kanji": "者",
+        "mean": "GIẢ"
+      }
+    ]
   },
   {
     "japanese": "カラオケ",
@@ -97,7 +167,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "clothing",
-    "example": "浴衣を着ます。"
+    "example": "浴衣を着ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "浴",
+        "mean": "DỤC"
+      },
+      {
+        "kanji": "衣",
+        "mean": "Y, Ý"
+      }
+    ]
   },
   {
     "japanese": "ペット",
@@ -137,7 +217,25 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "object",
-    "example": "目覚まし時計をセットします。"
+    "example": "目覚まし時計をセットします。",
+    "kanji_search_results": [
+      {
+        "kanji": "覚",
+        "mean": "GIÁC"
+      },
+      {
+        "kanji": "計",
+        "mean": "KẾ, KÊ"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "目",
+        "mean": "MỤC"
+      }
+    ]
   },
   {
     "japanese": "シャワー",
@@ -157,7 +255,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "body",
-    "example": "歯を磨きます。"
+    "example": "歯を磨きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "歯",
+        "mean": "XỈ"
+      }
+    ]
   },
   {
     "japanese": "スピーチ",
@@ -227,7 +331,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "sport",
-    "example": "空手を習います。"
+    "example": "空手を習います。",
+    "kanji_search_results": [
+      {
+        "kanji": "空",
+        "mean": "KHÔNG, KHỐNG, KHỔNG"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "きょく",
@@ -237,7 +351,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "music",
-    "example": "曲を歌います。"
+    "example": "曲を歌います。",
+    "kanji_search_results": [
+      {
+        "kanji": "曲",
+        "mean": "KHÚC"
+      }
+    ]
   },
   {
     "japanese": "まちます",
@@ -247,7 +367,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "友達を待ちます。"
+    "example": "友達を待ちます。",
+    "kanji_search_results": [
+      {
+        "kanji": "待",
+        "mean": "ĐÃI"
+      }
+    ]
   },
   {
     "japanese": "しにます",
@@ -257,7 +383,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "花が死にます。"
+    "example": "花が死にます。",
+    "kanji_search_results": [
+      {
+        "kanji": "死",
+        "mean": "TỬ"
+      }
+    ]
   },
   {
     "japanese": "ひきます",
@@ -267,7 +399,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ピアノを弾きます。"
+    "example": "ピアノを弾きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "弾",
+        "mean": "ĐÀN, ĐẠN"
+      }
+    ]
   },
   {
     "japanese": "できます",
@@ -287,7 +425,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "椅子に座ります。"
+    "example": "椅子に座ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "座",
+        "mean": "TỌA"
+      }
+    ]
   },
   {
     "japanese": "たちます",
@@ -297,7 +441,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "立って話します。"
+    "example": "立って話します。",
+    "kanji_search_results": [
+      {
+        "kanji": "立",
+        "mean": "LẬP"
+      }
+    ]
   },
   {
     "japanese": "はらいます",
@@ -307,7 +457,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "料金を払います。"
+    "example": "料金を払います。",
+    "kanji_search_results": [
+      {
+        "kanji": "払",
+        "mean": "PHẤT"
+      }
+    ]
   },
   {
     "japanese": "セットします",
@@ -327,7 +483,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "シャワーを浴びます。"
+    "example": "シャワーを浴びます。",
+    "kanji_search_results": [
+      {
+        "kanji": "浴",
+        "mean": "DỤC"
+      }
+    ]
   },
   {
     "japanese": "みがきます",
@@ -337,7 +499,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "歯を磨きます。"
+    "example": "歯を磨きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "磨",
+        "mean": "MA, MÁ"
+      }
+    ]
   },
   {
     "japanese": "けします",
@@ -347,7 +515,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "電気を消します。"
+    "example": "電気を消します。",
+    "kanji_search_results": [
+      {
+        "kanji": "消",
+        "mean": "TIÊU"
+      }
+    ]
   },
   {
     "japanese": "でかけます",
@@ -357,7 +531,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "買い物に出かけます。"
+    "example": "買い物に出かけます。",
+    "kanji_search_results": [
+      {
+        "kanji": "出",
+        "mean": "XUẤT, XÚY"
+      }
+    ]
   },
   {
     "japanese": "のります",
@@ -367,7 +547,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "電車に乗ります。"
+    "example": "電車に乗ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "乗",
+        "mean": "THỪA"
+      }
+    ]
   },
   {
     "japanese": "おります",
@@ -377,7 +563,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "電車を降ります。"
+    "example": "電車を降ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "降",
+        "mean": "HÀNG, GIÁNG"
+      }
+    ]
   },
   {
     "japanese": "はじめます",
@@ -387,7 +579,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "勉強を始めます。"
+    "example": "勉強を始めます。",
+    "kanji_search_results": [
+      {
+        "kanji": "始",
+        "mean": "THỦY, THÍ"
+      }
+    ]
   },
   {
     "japanese": "のせます",
@@ -397,7 +595,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ブログに写真を載せます。"
+    "example": "ブログに写真を載せます。",
+    "kanji_search_results": [
+      {
+        "kanji": "載",
+        "mean": "TÁI, TẠI, TẢI"
+      }
+    ]
   },
   {
     "japanese": "みせます",
@@ -407,7 +611,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "写真を見せます。"
+    "example": "写真を見せます。",
+    "kanji_search_results": [
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "なんメートル",
@@ -417,7 +627,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何メートルですか。"
+    "example": "何メートルですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      }
+    ]
   },
   {
     "japanese": "この まえ",
@@ -427,7 +643,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "time",
-    "example": "この前会いました。"
+    "example": "この前会いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      }
+    ]
   },
   {
     "japanese": "じぶんで",
@@ -437,7 +659,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "自分で作ります。"
+    "example": "自分で作ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      },
+      {
+        "kanji": "自",
+        "mean": "TỰ"
+      }
+    ]
   },
   {
     "japanese": "－メートル",
@@ -487,7 +719,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "place",
-    "example": "箱根に行きます。"
+    "example": "箱根に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "箱",
+        "mean": "TƯƠNG, SƯƠNG"
+      },
+      {
+        "kanji": "根",
+        "mean": "CĂN"
+      }
+    ]
   },
   {
     "japanese": "ながの",
@@ -497,7 +739,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "place",
-    "example": "長野でスキーをします。"
+    "example": "長野でスキーをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "野",
+        "mean": "DÃ"
+      },
+      {
+        "kanji": "長",
+        "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "みえ",
@@ -507,7 +759,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "place",
-    "example": "三重県に行きます。"
+    "example": "三重県に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "重",
+        "mean": "TRỌNG, TRÙNG"
+      },
+      {
+        "kanji": "三",
+        "mean": "TAM, TÁM"
+      }
+    ]
   },
   {
     "japanese": "にんじゃむら",
@@ -517,7 +779,21 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "place",
-    "example": "忍者村を見学します。"
+    "example": "忍者村を見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "忍",
+        "mean": "NHẪN"
+      },
+      {
+        "kanji": "村",
+        "mean": "THÔN"
+      },
+      {
+        "kanji": "者",
+        "mean": "GIẢ"
+      }
+    ]
   },
   {
     "japanese": "ぶんかセンター",
@@ -527,7 +803,17 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "place",
-    "example": "文化センターで勉強します。"
+    "example": "文化センターで勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "化",
+        "mean": "HÓA"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "ますけい",
@@ -537,7 +823,13 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "ます形を勉強します。"
+    "example": "ます形を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      }
+    ]
   },
   {
     "japanese": "じしょけい",
@@ -547,6 +839,20 @@
     "lesson": 14,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "辞書形を覚えます。"
+    "example": "辞書形を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "辞",
+        "mean": "TỪ"
+      }
+    ]
   }
 ]

--- a/data/lesson_15_vocabulary.json
+++ b/data/lesson_15_vocabulary.json
@@ -47,7 +47,21 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "参考書を買いました。"
+    "example": "参考書を買いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "考",
+        "mean": "KHẢO"
+      },
+      {
+        "kanji": "参",
+        "mean": "THAM, XAM, SÂM"
+      }
+    ]
   },
   {
     "japanese": "しりょう",
@@ -57,7 +71,17 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "document",
-    "example": "資料を集めています。"
+    "example": "資料を集めています。",
+    "kanji_search_results": [
+      {
+        "kanji": "資",
+        "mean": "TƯ"
+      },
+      {
+        "kanji": "料",
+        "mean": "LIÊU, LIỆU"
+      }
+    ]
   },
   {
     "japanese": "すいせんじょう",
@@ -67,7 +91,21 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "document",
-    "example": "推薦状を書いてください。"
+    "example": "推薦状を書いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "状",
+        "mean": "TRẠNG"
+      },
+      {
+        "kanji": "推",
+        "mean": "THÔI, SUY"
+      },
+      {
+        "kanji": "薦",
+        "mean": "TIẾN"
+      }
+    ]
   },
   {
     "japanese": "ごみ",
@@ -87,7 +125,17 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "household",
-    "example": "台所で料理をします。"
+    "example": "台所で料理をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "所",
+        "mean": "SỞ"
+      },
+      {
+        "kanji": "台",
+        "mean": "THAI, ĐÀI, DI"
+      }
+    ]
   },
   {
     "japanese": "コート",
@@ -107,7 +155,17 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "location",
-    "example": "住所を教えてください。"
+    "example": "住所を教えてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "所",
+        "mean": "SỞ"
+      },
+      {
+        "kanji": "住",
+        "mean": "TRỤ, TRÚ"
+      }
+    ]
   },
   {
     "japanese": "いそぐ",
@@ -117,7 +175,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "急いでください。"
+    "example": "急いでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "急",
+        "mean": "CẤP"
+      }
+    ]
   },
   {
     "japanese": "あつめる",
@@ -127,7 +191,13 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "資料を集めています。"
+    "example": "資料を集めています。",
+    "kanji_search_results": [
+      {
+        "kanji": "集",
+        "mean": "TẬP"
+      }
+    ]
   },
   {
     "japanese": "コピーする",
@@ -147,7 +217,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "野菜を切ってください。"
+    "example": "野菜を切ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
+      }
+    ]
   },
   {
     "japanese": "いれる",
@@ -157,7 +233,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お茶を入れてください。"
+    "example": "お茶を入れてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "入",
+        "mean": "NHẬP"
+      }
+    ]
   },
   {
     "japanese": "にる",
@@ -167,7 +249,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "野菜を煮てください。"
+    "example": "野菜を煮てください。",
+    "kanji_search_results": [
+      {
+        "kanji": "煮",
+        "mean": "CHỬ"
+      }
+    ]
   },
   {
     "japanese": "ならべる",
@@ -177,7 +265,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を並べてください。"
+    "example": "本を並べてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "並",
+        "mean": "TỊNH, TINH"
+      }
+    ]
   },
   {
     "japanese": "とる",
@@ -187,7 +281,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "写真を取ってください。"
+    "example": "写真を取ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "取",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "いう",
@@ -197,7 +297,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ありがとうと言いました。"
+    "example": "ありがとうと言いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "言",
+        "mean": "NGÔN, NGÂN"
+      }
+    ]
   },
   {
     "japanese": "しゅうりする",
@@ -207,7 +313,17 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "車を修理しました。"
+    "example": "車を修理しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "理",
+        "mean": "LÍ"
+      },
+      {
+        "kanji": "修",
+        "mean": "TU"
+      }
+    ]
   },
   {
     "japanese": "あがる",
@@ -217,7 +333,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "家に上がってください。"
+    "example": "家に上がってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "はく",
@@ -227,7 +349,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "靴を履いてください。"
+    "example": "靴を履いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "履",
+        "mean": "LÍ"
+      }
+    ]
   },
   {
     "japanese": "すてる",
@@ -237,7 +365,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ごみを捨ててください。"
+    "example": "ごみを捨ててください。",
+    "kanji_search_results": [
+      {
+        "kanji": "捨",
+        "mean": "XÁ, XẢ"
+      }
+    ]
   },
   {
     "japanese": "はこぶ",
@@ -247,7 +381,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "荷物を運んでください。"
+    "example": "荷物を運んでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "運",
+        "mean": "VẬN"
+      }
+    ]
   },
   {
     "japanese": "ふく",
@@ -267,7 +407,13 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "危ないですから気をつけてください。"
+    "example": "危ないですから気をつけてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "危",
+        "mean": "NGUY"
+      }
+    ]
   },
   {
     "japanese": "ほかの",
@@ -287,7 +433,17 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "もう一度言ってください。"
+    "example": "もう一度言ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "度",
+        "mean": "ĐỘ, ĐẠC"
+      },
+      {
+        "kanji": "一",
+        "mean": "NHẤT"
+      }
+    ]
   },
   {
     "japanese": "すぐ",
@@ -327,7 +483,17 @@
     "lesson": 15,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "失礼します。お先に失礼します。"
+    "example": "失礼します。お先に失礼します。",
+    "kanji_search_results": [
+      {
+        "kanji": "失",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "礼",
+        "mean": "LỄ"
+      }
+    ]
   },
   {
     "japanese": "いただきます",
@@ -367,6 +533,12 @@
     "lesson": 15,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "て形の使い方を勉強しています。"
+    "example": "て形の使い方を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      }
+    ]
   }
 ]

--- a/data/lesson_15_vocabulary.json
+++ b/data/lesson_15_vocabulary.json
@@ -50,16 +50,16 @@
     "example": "参考書を買いました。",
     "kanji_search_results": [
       {
-        "kanji": "書",
-        "mean": "THƯ"
+        "kanji": "参",
+        "mean": "THAM, XAM, SÂM"
       },
       {
         "kanji": "考",
         "mean": "KHẢO"
       },
       {
-        "kanji": "参",
-        "mean": "THAM, XAM, SÂM"
+        "kanji": "書",
+        "mean": "THƯ"
       }
     ]
   },
@@ -94,16 +94,16 @@
     "example": "推薦状を書いてください。",
     "kanji_search_results": [
       {
-        "kanji": "状",
-        "mean": "TRẠNG"
-      },
-      {
         "kanji": "推",
         "mean": "THÔI, SUY"
       },
       {
         "kanji": "薦",
         "mean": "TIẾN"
+      },
+      {
+        "kanji": "状",
+        "mean": "TRẠNG"
       }
     ]
   },
@@ -128,12 +128,12 @@
     "example": "台所で料理をします。",
     "kanji_search_results": [
       {
-        "kanji": "所",
-        "mean": "SỞ"
-      },
-      {
         "kanji": "台",
         "mean": "THAI, ĐÀI, DI"
+      },
+      {
+        "kanji": "所",
+        "mean": "SỞ"
       }
     ]
   },
@@ -158,12 +158,12 @@
     "example": "住所を教えてください。",
     "kanji_search_results": [
       {
-        "kanji": "所",
-        "mean": "SỞ"
-      },
-      {
         "kanji": "住",
         "mean": "TRỤ, TRÚ"
+      },
+      {
+        "kanji": "所",
+        "mean": "SỞ"
       }
     ]
   },
@@ -316,12 +316,12 @@
     "example": "車を修理しました。",
     "kanji_search_results": [
       {
-        "kanji": "理",
-        "mean": "LÍ"
-      },
-      {
         "kanji": "修",
         "mean": "TU"
+      },
+      {
+        "kanji": "理",
+        "mean": "LÍ"
       }
     ]
   },
@@ -436,12 +436,12 @@
     "example": "もう一度言ってください。",
     "kanji_search_results": [
       {
-        "kanji": "度",
-        "mean": "ĐỘ, ĐẠC"
-      },
-      {
         "kanji": "一",
         "mean": "NHẤT"
+      },
+      {
+        "kanji": "度",
+        "mean": "ĐỘ, ĐẠC"
       }
     ]
   },

--- a/data/lesson_16_vocabulary.json
+++ b/data/lesson_16_vocabulary.json
@@ -64,16 +64,16 @@
     "example": "美術館で絵を見ました。",
     "kanji_search_results": [
       {
+        "kanji": "美",
+        "mean": "MĨ"
+      },
+      {
         "kanji": "術",
         "mean": "THUẬT"
       },
       {
         "kanji": "館",
         "mean": "QUÁN"
-      },
-      {
-        "kanji": "美",
-        "mean": "MĨ"
       }
     ]
   },
@@ -154,12 +154,12 @@
     "example": "番号を確認してください。",
     "kanji_search_results": [
       {
-        "kanji": "号",
-        "mean": "HÀO, HIỆU"
-      },
-      {
         "kanji": "番",
         "mean": "PHIÊN, PHAN, BA, BÀ"
+      },
+      {
+        "kanji": "号",
+        "mean": "HÀO, HIỆU"
       }
     ]
   },
@@ -174,20 +174,20 @@
     "example": "電話番号を教えてください。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
         "kanji": "電",
         "mean": "ĐIỆN"
       },
       {
-        "kanji": "号",
-        "mean": "HÀO, HIỆU"
+        "kanji": "話",
+        "mean": "THOẠI"
       },
       {
         "kanji": "番",
         "mean": "PHIÊN, PHAN, BA, BÀ"
+      },
+      {
+        "kanji": "号",
+        "mean": "HÀO, HIỆU"
       }
     ]
   },
@@ -294,12 +294,12 @@
     "example": "祖父と散歩しました。",
     "kanji_search_results": [
       {
-        "kanji": "父",
-        "mean": "PHỤ, PHỦ"
-      },
-      {
         "kanji": "祖",
         "mean": "TỔ"
+      },
+      {
+        "kanji": "父",
+        "mean": "PHỤ, PHỦ"
       }
     ]
   },
@@ -374,20 +374,20 @@
     "example": "機械工学を勉強しています。",
     "kanji_search_results": [
       {
-        "kanji": "工",
-        "mean": "CÔNG"
-      },
-      {
         "kanji": "機",
         "mean": "KI, CƠ"
       },
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "械",
         "mean": "GIỚI"
+      },
+      {
+        "kanji": "工",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       }
     ]
   },
@@ -418,12 +418,12 @@
     "example": "お手伝いをします。",
     "kanji_search_results": [
       {
-        "kanji": "伝",
-        "mean": "TRUYỀN"
-      },
-      {
         "kanji": "手",
         "mean": "THỦ"
+      },
+      {
+        "kanji": "伝",
+        "mean": "TRUYỀN"
       }
     ]
   },
@@ -438,12 +438,12 @@
     "example": "本当ですか。",
     "kanji_search_results": [
       {
-        "kanji": "当",
-        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
-      },
-      {
         "kanji": "本",
         "mean": "BỔN, BẢN"
+      },
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
       }
     ]
   },
@@ -458,12 +458,12 @@
     "example": "毎年旅行をします。",
     "kanji_search_results": [
       {
-        "kanji": "年",
-        "mean": "NIÊN"
-      },
-      {
         "kanji": "毎",
         "mean": "MỖI"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
       }
     ]
   },
@@ -592,12 +592,12 @@
     "example": "会社を経営しています。",
     "kanji_search_results": [
       {
-        "kanji": "営",
-        "mean": "DOANH, DINH"
-      },
-      {
         "kanji": "経",
         "mean": "KINH"
+      },
+      {
+        "kanji": "営",
+        "mean": "DOANH, DINH"
       }
     ]
   },
@@ -660,12 +660,12 @@
     "example": "新宿で電車を乗り換えます。",
     "kanji_search_results": [
       {
-        "kanji": "換",
-        "mean": "HOÁN"
-      },
-      {
         "kanji": "乗",
         "mean": "THỪA"
+      },
+      {
+        "kanji": "換",
+        "mean": "HOÁN"
       }
     ]
   },
@@ -748,12 +748,12 @@
     "example": "お土産を持って来ました。",
     "kanji_search_results": [
       {
-        "kanji": "来",
-        "mean": "LAI, LÃI"
-      },
-      {
         "kanji": "持",
         "mean": "TRÌ"
+      },
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
       }
     ]
   },
@@ -768,12 +768,12 @@
     "example": "荷物を持って行きます。",
     "kanji_search_results": [
       {
-        "kanji": "行",
-        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
-      },
-      {
         "kanji": "持",
         "mean": "TRÌ"
+      },
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       }
     ]
   },
@@ -888,12 +888,12 @@
     "example": "上野の美術館に行きました。",
     "kanji_search_results": [
       {
-        "kanji": "野",
-        "mean": "DÃ"
-      },
-      {
         "kanji": "上",
         "mean": "THƯỢNG, THƯỚNG"
+      },
+      {
+        "kanji": "野",
+        "mean": "DÃ"
       }
     ]
   }

--- a/data/lesson_16_vocabulary.json
+++ b/data/lesson_16_vocabulary.json
@@ -7,7 +7,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "food",
-    "example": "お菓子を買いました。"
+    "example": "お菓子を買いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "菓",
+        "mean": "QUẢ"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "たばこ",
@@ -27,7 +37,21 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "person",
-    "example": "中学生の時、野球をしていました。"
+    "example": "中学生の時、野球をしていました。",
+    "kanji_search_results": [
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "びじゅつかん",
@@ -37,7 +61,21 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "美術館で絵を見ました。"
+    "example": "美術館で絵を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "術",
+        "mean": "THUẬT"
+      },
+      {
+        "kanji": "館",
+        "mean": "QUÁN"
+      },
+      {
+        "kanji": "美",
+        "mean": "MĨ"
+      }
+    ]
   },
   {
     "japanese": "ふく",
@@ -47,7 +85,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "clothing",
-    "example": "新しい服を買いました。"
+    "example": "新しい服を買いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "服",
+        "mean": "PHỤC"
+      }
+    ]
   },
   {
     "japanese": "デザイン",
@@ -67,7 +111,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "work",
-    "example": "会社で働いています。"
+    "example": "会社で働いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "社",
+        "mean": "XÃ"
+      }
+    ]
   },
   {
     "japanese": "ばしょ",
@@ -77,7 +131,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "location",
-    "example": "会議の場所を教えてください。"
+    "example": "会議の場所を教えてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "場",
+        "mean": "TRÀNG, TRƯỜNG"
+      },
+      {
+        "kanji": "所",
+        "mean": "SỞ"
+      }
+    ]
   },
   {
     "japanese": "ばんごう",
@@ -87,7 +151,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "number",
-    "example": "番号を確認してください。"
+    "example": "番号を確認してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "号",
+        "mean": "HÀO, HIỆU"
+      },
+      {
+        "kanji": "番",
+        "mean": "PHIÊN, PHAN, BA, BÀ"
+      }
+    ]
   },
   {
     "japanese": "でんわばんごう",
@@ -97,7 +171,25 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "contact",
-    "example": "電話番号を教えてください。"
+    "example": "電話番号を教えてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "号",
+        "mean": "HÀO, HIỆU"
+      },
+      {
+        "kanji": "番",
+        "mean": "PHIÊN, PHAN, BA, BÀ"
+      }
+    ]
   },
   {
     "japanese": "メールアドレス",
@@ -127,7 +219,13 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "building",
-    "example": "お城を見学しました。"
+    "example": "お城を見学しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "城",
+        "mean": "THÀNH"
+      }
+    ]
   },
   {
     "japanese": "おひめさま",
@@ -137,7 +235,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "person",
-    "example": "お姫様のような人です。"
+    "example": "お姫様のような人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "姫",
+        "mean": "CƠ"
+      },
+      {
+        "kanji": "様",
+        "mean": "DẠNG"
+      }
+    ]
   },
   {
     "japanese": "おどり",
@@ -147,7 +255,13 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "踊りを習っています。"
+    "example": "踊りを習っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "踊",
+        "mean": "DŨNG"
+      }
+    ]
   },
   {
     "japanese": "そぼ",
@@ -157,7 +271,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "family",
-    "example": "祖母は元気です。"
+    "example": "祖母は元気です。",
+    "kanji_search_results": [
+      {
+        "kanji": "祖",
+        "mean": "TỔ"
+      },
+      {
+        "kanji": "母",
+        "mean": "MẪU, MÔ"
+      }
+    ]
   },
   {
     "japanese": "そふ",
@@ -167,7 +291,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "family",
-    "example": "祖父と散歩しました。"
+    "example": "祖父と散歩しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "父",
+        "mean": "PHỤ, PHỦ"
+      },
+      {
+        "kanji": "祖",
+        "mean": "TỔ"
+      }
+    ]
   },
   {
     "japanese": "おばあさん",
@@ -197,7 +331,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "work",
-    "example": "翻訳の仕事をしています。"
+    "example": "翻訳の仕事をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "翻",
+        "mean": "PHIÊN"
+      },
+      {
+        "kanji": "訳",
+        "mean": "DỊCH"
+      }
+    ]
   },
   {
     "japanese": "きかい",
@@ -207,7 +351,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "technology",
-    "example": "機械を操作します。"
+    "example": "機械を操作します。",
+    "kanji_search_results": [
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "械",
+        "mean": "GIỚI"
+      }
+    ]
   },
   {
     "japanese": "きかいこうがく",
@@ -217,7 +371,25 @@
     "lesson": 16,
     "difficulty": "advanced",
     "category": "education",
-    "example": "機械工学を勉強しています。"
+    "example": "機械工学を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "工",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "械",
+        "mean": "GIỚI"
+      }
+    ]
   },
   {
     "japanese": "なか",
@@ -227,7 +399,13 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "仲がいいです。"
+    "example": "仲がいいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "仲",
+        "mean": "TRỌNG"
+      }
+    ]
   },
   {
     "japanese": "てつだい",
@@ -237,7 +415,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "お手伝いをします。"
+    "example": "お手伝いをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "伝",
+        "mean": "TRUYỀN"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "ほんとう",
@@ -247,7 +435,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "本当ですか。"
+    "example": "本当ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      }
+    ]
   },
   {
     "japanese": "まいとし",
@@ -257,7 +455,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎年旅行をします。"
+    "example": "毎年旅行をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      },
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      }
+    ]
   },
   {
     "japanese": "まいつき",
@@ -267,7 +475,17 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎月会議があります。"
+    "example": "毎月会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "チェックする",
@@ -287,7 +505,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を机に置いてください。"
+    "example": "本を机に置いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "置",
+        "mean": "TRÍ"
+      }
+    ]
   },
   {
     "japanese": "とめる",
@@ -297,7 +521,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "車を止めてください。"
+    "example": "車を止めてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "止",
+        "mean": "CHỈ"
+      }
+    ]
   },
   {
     "japanese": "すう",
@@ -307,7 +537,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "たばこを吸わないでください。"
+    "example": "たばこを吸わないでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "吸",
+        "mean": "HẤP"
+      }
+    ]
   },
   {
     "japanese": "けっこんする",
@@ -317,7 +553,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "来年結婚する予定です。"
+    "example": "来年結婚する予定です。",
+    "kanji_search_results": [
+      {
+        "kanji": "結",
+        "mean": "KẾT"
+      },
+      {
+        "kanji": "婚",
+        "mean": "HÔN"
+      }
+    ]
   },
   {
     "japanese": "すむ",
@@ -327,7 +573,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "東京に住んでいます。"
+    "example": "東京に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "住",
+        "mean": "TRỤ, TRÚ"
+      }
+    ]
   },
   {
     "japanese": "けいえいする",
@@ -337,7 +589,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "会社を経営しています。"
+    "example": "会社を経営しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "営",
+        "mean": "DOANH, DINH"
+      },
+      {
+        "kanji": "経",
+        "mean": "KINH"
+      }
+    ]
   },
   {
     "japanese": "しる",
@@ -347,7 +609,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "その人を知っていますか。"
+    "example": "その人を知っていますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "知",
+        "mean": "TRI, TRÍ"
+      }
+    ]
   },
   {
     "japanese": "きく",
@@ -357,7 +625,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "先生に聞いてください。"
+    "example": "先生に聞いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "聞",
+        "mean": "VĂN, VẤN, VẶN"
+      }
+    ]
   },
   {
     "japanese": "たすける",
@@ -367,7 +641,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "困っている人を助けてください。"
+    "example": "困っている人を助けてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "助",
+        "mean": "TRỢ"
+      }
+    ]
   },
   {
     "japanese": "のりかえる",
@@ -377,7 +657,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "新宿で電車を乗り換えます。"
+    "example": "新宿で電車を乗り換えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "換",
+        "mean": "HOÁN"
+      },
+      {
+        "kanji": "乗",
+        "mean": "THỪA"
+      }
+    ]
   },
   {
     "japanese": "たいしょくする",
@@ -387,7 +677,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "来年退職する予定です。"
+    "example": "来年退職する予定です。",
+    "kanji_search_results": [
+      {
+        "kanji": "退",
+        "mean": "THỐI, THOÁI"
+      },
+      {
+        "kanji": "職",
+        "mean": "CHỨC"
+      }
+    ]
   },
   {
     "japanese": "さわる",
@@ -397,7 +697,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "触らないでください。"
+    "example": "触らないでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "触",
+        "mean": "XÚC"
+      }
+    ]
   },
   {
     "japanese": "いれる",
@@ -407,7 +713,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お茶を入れてください。"
+    "example": "お茶を入れてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "入",
+        "mean": "NHẬP"
+      }
+    ]
   },
   {
     "japanese": "やく",
@@ -417,7 +729,13 @@
     "lesson": 16,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "パンを焼いてください。"
+    "example": "パンを焼いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "焼",
+        "mean": "THIÊU"
+      }
+    ]
   },
   {
     "japanese": "もって くる",
@@ -427,7 +745,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "お土産を持って来ました。"
+    "example": "お土産を持って来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      },
+      {
+        "kanji": "持",
+        "mean": "TRÌ"
+      }
+    ]
   },
   {
     "japanese": "もって いく",
@@ -437,7 +765,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "荷物を持って行きます。"
+    "example": "荷物を持って行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "持",
+        "mean": "TRÌ"
+      }
+    ]
   },
   {
     "japanese": "やくに たつ",
@@ -447,7 +785,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "この本は役に立ちます。"
+    "example": "この本は役に立ちます。",
+    "kanji_search_results": [
+      {
+        "kanji": "役",
+        "mean": "DỊCH"
+      },
+      {
+        "kanji": "立",
+        "mean": "LẬP"
+      }
+    ]
   },
   {
     "japanese": "すごい",
@@ -517,7 +865,17 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "新宿で買い物をしました。"
+    "example": "新宿で買い物をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "新",
+        "mean": "TÂN"
+      },
+      {
+        "kanji": "宿",
+        "mean": "TÚC, TÚ"
+      }
+    ]
   },
   {
     "japanese": "うえの",
@@ -527,6 +885,16 @@
     "lesson": 16,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "上野の美術館に行きました。"
+    "example": "上野の美術館に行きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "野",
+        "mean": "DÃ"
+      },
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      }
+    ]
   }
 ]

--- a/data/lesson_17_vocabulary.json
+++ b/data/lesson_17_vocabulary.json
@@ -27,7 +27,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "place",
-    "example": "池で魚を釣りました。"
+    "example": "池で魚を釣りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "池",
+        "mean": "TRÌ"
+      }
+    ]
   },
   {
     "japanese": "えだ",
@@ -37,7 +43,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "木の枝が折れました。"
+    "example": "木の枝が折れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "枝",
+        "mean": "CHI, KÌ"
+      }
+    ]
   },
   {
     "japanese": "せんせい",
@@ -47,7 +59,17 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "person",
-    "example": "先生に質問しました。"
+    "example": "先生に質問しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "ぜいきん",
@@ -57,7 +79,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "money",
-    "example": "税金を払いました。"
+    "example": "税金を払いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "税",
+        "mean": "THUẾ, THỐI, THOÁT"
+      },
+      {
+        "kanji": "金",
+        "mean": "KIM"
+      }
+    ]
   },
   {
     "japanese": "しけん",
@@ -67,7 +99,17 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "education",
-    "example": "試験を受けました。"
+    "example": "試験を受けました。",
+    "kanji_search_results": [
+      {
+        "kanji": "試",
+        "mean": "THÍ"
+      },
+      {
+        "kanji": "験",
+        "mean": "NGHIỆM"
+      }
+    ]
   },
   {
     "japanese": "さくぶん",
@@ -77,7 +119,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "作文を書きました。"
+    "example": "作文を書きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "作",
+        "mean": "TÁC"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "おうさま",
@@ -87,7 +139,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "person",
-    "example": "王様が城に住んでいます。"
+    "example": "王様が城に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "様",
+        "mean": "DẠNG"
+      },
+      {
+        "kanji": "王",
+        "mean": "VƯƠNG, VƯỢNG"
+      }
+    ]
   },
   {
     "japanese": "ちゅうがく",
@@ -97,7 +159,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "中学で勉強しました。"
+    "example": "中学で勉強しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      }
+    ]
   },
   {
     "japanese": "こうこう",
@@ -107,7 +179,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "高校を卒業しました。"
+    "example": "高校を卒業しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "高",
+        "mean": "CAO"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      }
+    ]
   },
   {
     "japanese": "でんげん",
@@ -117,7 +199,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "technology",
-    "example": "電源を切ってください。"
+    "example": "電源を切ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "源",
+        "mean": "NGUYÊN"
+      }
+    ]
   },
   {
     "japanese": "ファイル",
@@ -147,7 +239,17 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "sports",
-    "example": "試合を見ました。"
+    "example": "試合を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "試",
+        "mean": "THÍ"
+      },
+      {
+        "kanji": "合",
+        "mean": "HỢP, CÁP, HIỆP"
+      }
+    ]
   },
   {
     "japanese": "せん",
@@ -157,7 +259,13 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "household",
-    "example": "栓を開けてください。"
+    "example": "栓を開けてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "栓",
+        "mean": "XUYÊN"
+      }
+    ]
   },
   {
     "japanese": "ゆ",
@@ -167,7 +275,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "household",
-    "example": "お湯を沸かしました。"
+    "example": "お湯を沸かしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "湯",
+        "mean": "THANG, SƯƠNG, THÃNG"
+      }
+    ]
   },
   {
     "japanese": "タオル",
@@ -187,7 +301,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "time",
-    "example": "２、３日待ってください。"
+    "example": "２、３日待ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "なく",
@@ -197,7 +317,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "赤ちゃんが泣いています。"
+    "example": "赤ちゃんが泣いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "泣",
+        "mean": "KHẤP"
+      }
+    ]
   },
   {
     "japanese": "わらう",
@@ -207,7 +333,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "みんなで笑いました。"
+    "example": "みんなで笑いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "笑",
+        "mean": "TIẾU"
+      }
+    ]
   },
   {
     "japanese": "おす",
@@ -217,7 +349,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ボタンを押してください。"
+    "example": "ボタンを押してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "押",
+        "mean": "ÁP"
+      }
+    ]
   },
   {
     "japanese": "おこる",
@@ -227,7 +365,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "先生が怒りました。"
+    "example": "先生が怒りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "怒",
+        "mean": "NỘ"
+      }
+    ]
   },
   {
     "japanese": "やる",
@@ -247,7 +391,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "紙を折ってください。"
+    "example": "紙を折ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "折",
+        "mean": "CHIẾT, ĐỀ"
+      }
+    ]
   },
   {
     "japanese": "うんてんする",
@@ -257,7 +407,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "車を運転しました。"
+    "example": "車を運転しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "転",
+        "mean": "CHUYỂN"
+      },
+      {
+        "kanji": "運",
+        "mean": "VẬN"
+      }
+    ]
   },
   {
     "japanese": "うける",
@@ -267,7 +427,13 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "試験を受けました。"
+    "example": "試験を受けました。",
+    "kanji_search_results": [
+      {
+        "kanji": "受",
+        "mean": "THỤ"
+      }
+    ]
   },
   {
     "japanese": "ならぶ",
@@ -277,7 +443,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "列に並んでください。"
+    "example": "列に並んでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "並",
+        "mean": "TỊNH, TINH"
+      }
+    ]
   },
   {
     "japanese": "あやまる",
@@ -287,7 +459,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "友達に謝りました。"
+    "example": "友達に謝りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "謝",
+        "mean": "TẠ"
+      }
+    ]
   },
   {
     "japanese": "そつぎょうする",
@@ -297,7 +475,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "大学を卒業しました。"
+    "example": "大学を卒業しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
+      },
+      {
+        "kanji": "卒",
+        "mean": "TỐT, TUẤT, THỐT"
+      }
+    ]
   },
   {
     "japanese": "きる",
@@ -307,7 +495,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "テレビを切ってください。"
+    "example": "テレビを切ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
+      }
+    ]
   },
   {
     "japanese": "ほぞんする",
@@ -317,7 +511,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "ファイルを保存しました。"
+    "example": "ファイルを保存しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "保",
+        "mean": "BẢO"
+      },
+      {
+        "kanji": "存",
+        "mean": "TỒN"
+      }
+    ]
   },
   {
     "japanese": "そうしんする",
@@ -327,7 +531,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "メールを送信しました。"
+    "example": "メールを送信しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "信",
+        "mean": "TÍN"
+      },
+      {
+        "kanji": "送",
+        "mean": "TỐNG"
+      }
+    ]
   },
   {
     "japanese": "さくじょする",
@@ -337,7 +551,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "ファイルを削除しました。"
+    "example": "ファイルを削除しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "除",
+        "mean": "TRỪ"
+      },
+      {
+        "kanji": "削",
+        "mean": "TƯỚC"
+      }
+    ]
   },
   {
     "japanese": "とうろくする",
@@ -347,7 +571,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "会員に登録しました。"
+    "example": "会員に登録しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "録",
+        "mean": "LỤC"
+      },
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
+      }
+    ]
   },
   {
     "japanese": "やる",
@@ -377,7 +611,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "栓を抜いてください。"
+    "example": "栓を抜いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "抜",
+        "mean": "BẠT"
+      }
+    ]
   },
   {
     "japanese": "でる",
@@ -387,7 +627,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お風呂から出ました。"
+    "example": "お風呂から出ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "出",
+        "mean": "XUẤT, XÚY"
+      }
+    ]
   },
   {
     "japanese": "ある",
@@ -407,7 +653,17 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "試験を頑張ってください。"
+    "example": "試験を頑張ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "張",
+        "mean": "TRƯƠNG, TRƯỚNG"
+      },
+      {
+        "kanji": "頑",
+        "mean": "NGOAN"
+      }
+    ]
   },
   {
     "japanese": "むりを する",
@@ -417,7 +673,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "無理をしないでください。"
+    "example": "無理をしないでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "理",
+        "mean": "LÍ"
+      },
+      {
+        "kanji": "無",
+        "mean": "VÔ, MÔ"
+      }
+    ]
   },
   {
     "japanese": "ない",
@@ -447,7 +713,17 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "全部食べました。"
+    "example": "全部食べました。",
+    "kanji_search_results": [
+      {
+        "kanji": "部",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "全",
+        "mean": "TOÀN"
+      }
+    ]
   },
   {
     "japanese": "さきに",
@@ -457,7 +733,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "先に帰ります。"
+    "example": "先に帰ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      }
+    ]
   },
   {
     "japanese": "もう すこし",
@@ -467,7 +749,13 @@
     "lesson": 17,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "もう少し待ってください。"
+    "example": "もう少し待ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "少",
+        "mean": "THIỂU, THIẾU"
+      }
+    ]
   },
   {
     "japanese": "ううん",
@@ -487,7 +775,17 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "市民グラウンドで運動しました。"
+    "example": "市民グラウンドで運動しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "市",
+        "mean": "THỊ"
+      },
+      {
+        "kanji": "民",
+        "mean": "DÂN"
+      }
+    ]
   },
   {
     "japanese": "おめでとう ございます",
@@ -507,6 +805,12 @@
     "lesson": 17,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "ない形の使い方を勉強しています。"
+    "example": "ない形の使い方を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      }
+    ]
   }
 ]

--- a/data/lesson_17_vocabulary.json
+++ b/data/lesson_17_vocabulary.json
@@ -142,12 +142,12 @@
     "example": "王様が城に住んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "様",
-        "mean": "DẠNG"
-      },
-      {
         "kanji": "王",
         "mean": "VƯƠNG, VƯỢNG"
+      },
+      {
+        "kanji": "様",
+        "mean": "DẠNG"
       }
     ]
   },
@@ -410,12 +410,12 @@
     "example": "車を運転しました。",
     "kanji_search_results": [
       {
-        "kanji": "転",
-        "mean": "CHUYỂN"
-      },
-      {
         "kanji": "運",
         "mean": "VẬN"
+      },
+      {
+        "kanji": "転",
+        "mean": "CHUYỂN"
       }
     ]
   },
@@ -478,12 +478,12 @@
     "example": "大学を卒業しました。",
     "kanji_search_results": [
       {
-        "kanji": "業",
-        "mean": "NGHIỆP"
-      },
-      {
         "kanji": "卒",
         "mean": "TỐT, TUẤT, THỐT"
+      },
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
       }
     ]
   },
@@ -534,12 +534,12 @@
     "example": "メールを送信しました。",
     "kanji_search_results": [
       {
-        "kanji": "信",
-        "mean": "TÍN"
-      },
-      {
         "kanji": "送",
         "mean": "TỐNG"
+      },
+      {
+        "kanji": "信",
+        "mean": "TÍN"
       }
     ]
   },
@@ -554,12 +554,12 @@
     "example": "ファイルを削除しました。",
     "kanji_search_results": [
       {
-        "kanji": "除",
-        "mean": "TRỪ"
-      },
-      {
         "kanji": "削",
         "mean": "TƯỚC"
+      },
+      {
+        "kanji": "除",
+        "mean": "TRỪ"
       }
     ]
   },
@@ -574,12 +574,12 @@
     "example": "会員に登録しました。",
     "kanji_search_results": [
       {
-        "kanji": "録",
-        "mean": "LỤC"
-      },
-      {
         "kanji": "登",
         "mean": "ĐĂNG"
+      },
+      {
+        "kanji": "録",
+        "mean": "LỤC"
       }
     ]
   },
@@ -656,12 +656,12 @@
     "example": "試験を頑張ってください。",
     "kanji_search_results": [
       {
-        "kanji": "張",
-        "mean": "TRƯƠNG, TRƯỚNG"
-      },
-      {
         "kanji": "頑",
         "mean": "NGOAN"
+      },
+      {
+        "kanji": "張",
+        "mean": "TRƯƠNG, TRƯỚNG"
       }
     ]
   },
@@ -676,12 +676,12 @@
     "example": "無理をしないでください。",
     "kanji_search_results": [
       {
-        "kanji": "理",
-        "mean": "LÍ"
-      },
-      {
         "kanji": "無",
         "mean": "VÔ, MÔ"
+      },
+      {
+        "kanji": "理",
+        "mean": "LÍ"
       }
     ]
   },
@@ -716,12 +716,12 @@
     "example": "全部食べました。",
     "kanji_search_results": [
       {
-        "kanji": "部",
-        "mean": "BỘ"
-      },
-      {
         "kanji": "全",
         "mean": "TOÀN"
+      },
+      {
+        "kanji": "部",
+        "mean": "BỘ"
       }
     ]
   },

--- a/data/lesson_18_vocabulary.json
+++ b/data/lesson_18_vocabulary.json
@@ -7,7 +7,21 @@
     "lesson": 18,
     "difficulty": "advanced",
     "category": "culture",
-    "example": "歌舞伎を見に行きました。"
+    "example": "歌舞伎を見に行きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "伎",
+        "mean": "KĨ"
+      },
+      {
+        "kanji": "歌",
+        "mean": "CA"
+      },
+      {
+        "kanji": "舞",
+        "mean": "VŨ"
+      }
+    ]
   },
   {
     "japanese": "ぼんおどり",
@@ -17,7 +31,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "culture",
-    "example": "盆踊りに参加しました。"
+    "example": "盆踊りに参加しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "踊",
+        "mean": "DŨNG"
+      },
+      {
+        "kanji": "盆",
+        "mean": "BỒN"
+      }
+    ]
   },
   {
     "japanese": "パンフレット",
@@ -37,7 +61,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "来月引っ越しします。"
+    "example": "来月引っ越しします。",
+    "kanji_search_results": [
+      {
+        "kanji": "引",
+        "mean": "DẪN, DẤN"
+      },
+      {
+        "kanji": "越",
+        "mean": "VIỆT, HOẠT"
+      }
+    ]
   },
   {
     "japanese": "ガス",
@@ -57,7 +91,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "company",
-    "example": "ガス会社に連絡しました。"
+    "example": "ガス会社に連絡しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "社",
+        "mean": "XÃ"
+      }
+    ]
   },
   {
     "japanese": "すいどう",
@@ -67,7 +111,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "utility",
-    "example": "水道を止めてください。"
+    "example": "水道を止めてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "道",
+        "mean": "ĐẠO, ĐÁO"
+      },
+      {
+        "kanji": "水",
+        "mean": "THỦY"
+      }
+    ]
   },
   {
     "japanese": "ろんぶん",
@@ -77,7 +131,17 @@
     "lesson": 18,
     "difficulty": "advanced",
     "category": "education",
-    "example": "論文を書いています。"
+    "example": "論文を書いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "論",
+        "mean": "LUẬN, LUÂN"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "わすれもの",
@@ -87,7 +151,17 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "item",
-    "example": "忘れ物をしました。"
+    "example": "忘れ物をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      },
+      {
+        "kanji": "忘",
+        "mean": "VONG"
+      }
+    ]
   },
   {
     "japanese": "こいびと",
@@ -97,7 +171,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "person",
-    "example": "恋人がいます。"
+    "example": "恋人がいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "恋",
+        "mean": "LUYẾN"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "なっとう",
@@ -107,7 +191,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "food",
-    "example": "納豆を食べました。"
+    "example": "納豆を食べました。",
+    "kanji_search_results": [
+      {
+        "kanji": "納",
+        "mean": "NẠP"
+      },
+      {
+        "kanji": "豆",
+        "mean": "ĐẬU"
+      }
+    ]
   },
   {
     "japanese": "ぞう",
@@ -117,7 +211,13 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "animal",
-    "example": "象が大きいです。"
+    "example": "象が大きいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "象",
+        "mean": "TƯỢNG"
+      }
+    ]
   },
   {
     "japanese": "あくしゅ",
@@ -127,7 +227,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "action",
-    "example": "握手をしました。"
+    "example": "握手をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "握",
+        "mean": "ÁC"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "さがす",
@@ -137,7 +247,13 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "鍵を探しています。"
+    "example": "鍵を探しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "探",
+        "mean": "THAM, THÁM"
+      }
+    ]
   },
   {
     "japanese": "にづくりする",
@@ -147,7 +263,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "荷造りを手伝ってください。"
+    "example": "荷造りを手伝ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "造",
+        "mean": "TẠO, THÁO"
+      },
+      {
+        "kanji": "荷",
+        "mean": "HÀ, HẠ"
+      }
+    ]
   },
   {
     "japanese": "れんらくする",
@@ -157,7 +283,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "先生に連絡しました。"
+    "example": "先生に連絡しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "絡",
+        "mean": "LẠC"
+      },
+      {
+        "kanji": "連",
+        "mean": "LIÊN"
+      }
+    ]
   },
   {
     "japanese": "きが つく",
@@ -167,7 +303,13 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "間違いに気がつきました。"
+    "example": "間違いに気がつきました。",
+    "kanji_search_results": [
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      }
+    ]
   },
   {
     "japanese": "だす",
@@ -177,7 +319,13 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "宿題を出してください。"
+    "example": "宿題を出してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "出",
+        "mean": "XUẤT, XÚY"
+      }
+    ]
   },
   {
     "japanese": "しっぱいする",
@@ -187,7 +335,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "試験に失敗しました。"
+    "example": "試験に失敗しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "失",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "敗",
+        "mean": "BẠI"
+      }
+    ]
   },
   {
     "japanese": "わかれる",
@@ -197,7 +355,13 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "友達と別れました。"
+    "example": "友達と別れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "別",
+        "mean": "BIỆT"
+      }
+    ]
   },
   {
     "japanese": "かんせいする",
@@ -207,7 +371,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "仕事が完成しました。"
+    "example": "仕事が完成しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "成",
+        "mean": "THÀNH"
+      },
+      {
+        "kanji": "完",
+        "mean": "HOÀN"
+      }
+    ]
   },
   {
     "japanese": "おもいだす",
@@ -217,7 +391,17 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "昔のことを思い出しました。"
+    "example": "昔のことを思い出しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "思",
+        "mean": "TƯ, TỨ, TAI"
+      },
+      {
+        "kanji": "出",
+        "mean": "XUẤT, XÚY"
+      }
+    ]
   },
   {
     "japanese": "たのしみに する",
@@ -227,7 +411,13 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "旅行を楽しみにしています。"
+    "example": "旅行を楽しみにしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "楽",
+        "mean": "LẠC, NHẠC"
+      }
+    ]
   },
   {
     "japanese": "だいすき",
@@ -237,7 +427,17 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "音楽が大好きです。"
+    "example": "音楽が大好きです。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "好",
+        "mean": "HẢO, HIẾU"
+      }
+    ]
   },
   {
     "japanese": "かい",
@@ -247,7 +447,13 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "counter",
-    "example": "三回練習しました。"
+    "example": "三回練習しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "回",
+        "mean": "HỒI, HỐI"
+      }
+    ]
   },
   {
     "japanese": "なんかい",
@@ -257,7 +463,17 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何回練習しましたか。"
+    "example": "何回練習しましたか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "回",
+        "mean": "HỒI, HỐI"
+      }
+    ]
   },
   {
     "japanese": "ホームステイする",
@@ -347,7 +563,13 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "た形の使い方を勉強しています。"
+    "example": "た形の使い方を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      }
+    ]
   },
   {
     "japanese": "ピザ",
@@ -367,7 +589,25 @@
     "lesson": 18,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "専門学校に通っています。"
+    "example": "専門学校に通っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "専",
+        "mean": "CHUYÊN"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      },
+      {
+        "kanji": "門",
+        "mean": "MÔN"
+      }
+    ]
   },
   {
     "japanese": "カップ",
@@ -417,7 +657,13 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "仕事を見つけました。"
+    "example": "仕事を見つけました。",
+    "kanji_search_results": [
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "ほんとうに",
@@ -427,6 +673,16 @@
     "lesson": 18,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "本当にありがとうございます。"
+    "example": "本当にありがとうございます。",
+    "kanji_search_results": [
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      }
+    ]
   }
 ]

--- a/data/lesson_18_vocabulary.json
+++ b/data/lesson_18_vocabulary.json
@@ -10,16 +10,16 @@
     "example": "歌舞伎を見に行きました。",
     "kanji_search_results": [
       {
-        "kanji": "伎",
-        "mean": "KĨ"
-      },
-      {
         "kanji": "歌",
         "mean": "CA"
       },
       {
         "kanji": "舞",
         "mean": "VŨ"
+      },
+      {
+        "kanji": "伎",
+        "mean": "KĨ"
       }
     ]
   },
@@ -34,12 +34,12 @@
     "example": "盆踊りに参加しました。",
     "kanji_search_results": [
       {
-        "kanji": "踊",
-        "mean": "DŨNG"
-      },
-      {
         "kanji": "盆",
         "mean": "BỒN"
+      },
+      {
+        "kanji": "踊",
+        "mean": "DŨNG"
       }
     ]
   },
@@ -114,12 +114,12 @@
     "example": "水道を止めてください。",
     "kanji_search_results": [
       {
-        "kanji": "道",
-        "mean": "ĐẠO, ĐÁO"
-      },
-      {
         "kanji": "水",
         "mean": "THỦY"
+      },
+      {
+        "kanji": "道",
+        "mean": "ĐẠO, ĐÁO"
       }
     ]
   },
@@ -154,12 +154,12 @@
     "example": "忘れ物をしました。",
     "kanji_search_results": [
       {
-        "kanji": "物",
-        "mean": "VẬT"
-      },
-      {
         "kanji": "忘",
         "mean": "VONG"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
       }
     ]
   },
@@ -266,12 +266,12 @@
     "example": "荷造りを手伝ってください。",
     "kanji_search_results": [
       {
-        "kanji": "造",
-        "mean": "TẠO, THÁO"
-      },
-      {
         "kanji": "荷",
         "mean": "HÀ, HẠ"
+      },
+      {
+        "kanji": "造",
+        "mean": "TẠO, THÁO"
       }
     ]
   },
@@ -286,12 +286,12 @@
     "example": "先生に連絡しました。",
     "kanji_search_results": [
       {
-        "kanji": "絡",
-        "mean": "LẠC"
-      },
-      {
         "kanji": "連",
         "mean": "LIÊN"
+      },
+      {
+        "kanji": "絡",
+        "mean": "LẠC"
       }
     ]
   },
@@ -374,12 +374,12 @@
     "example": "仕事が完成しました。",
     "kanji_search_results": [
       {
-        "kanji": "成",
-        "mean": "THÀNH"
-      },
-      {
         "kanji": "完",
         "mean": "HOÀN"
+      },
+      {
+        "kanji": "成",
+        "mean": "THÀNH"
       }
     ]
   },
@@ -596,16 +596,16 @@
         "mean": "CHUYÊN"
       },
       {
+        "kanji": "門",
+        "mean": "MÔN"
+      },
+      {
         "kanji": "学",
         "mean": "HỌC"
       },
       {
         "kanji": "校",
         "mean": "GIÁO, HIỆU, HÀO"
-      },
-      {
-        "kanji": "門",
-        "mean": "MÔN"
       }
     ]
   },
@@ -676,12 +676,12 @@
     "example": "本当にありがとうございます。",
     "kanji_search_results": [
       {
-        "kanji": "当",
-        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
-      },
-      {
         "kanji": "本",
         "mean": "BỔN, BẢN"
+      },
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
       }
     ]
   }

--- a/data/lesson_19_vocabulary.json
+++ b/data/lesson_19_vocabulary.json
@@ -10,12 +10,12 @@
     "example": "地球を守りましょう。",
     "kanji_search_results": [
       {
-        "kanji": "球",
-        "mean": "CẦU"
-      },
-      {
         "kanji": "地",
         "mean": "ĐỊA"
+      },
+      {
+        "kanji": "球",
+        "mean": "CẦU"
       }
     ]
   },
@@ -30,12 +30,12 @@
     "example": "人口が増えています。",
     "kanji_search_results": [
       {
-        "kanji": "口",
-        "mean": "KHẨU"
-      },
-      {
         "kanji": "人",
         "mean": "NHÂN"
+      },
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
       }
     ]
   },
@@ -152,12 +152,12 @@
     "example": "用事があります。",
     "kanji_search_results": [
       {
-        "kanji": "事",
-        "mean": "SỰ"
-      },
-      {
         "kanji": "用",
         "mean": "DỤNG"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
       }
     ]
   },
@@ -172,16 +172,16 @@
     "example": "忘年会に参加しました。",
     "kanji_search_results": [
       {
-        "kanji": "会",
-        "mean": "HỘI, CỐI"
+        "kanji": "忘",
+        "mean": "VONG"
       },
       {
         "kanji": "年",
         "mean": "NIÊN"
       },
       {
-        "kanji": "忘",
-        "mean": "VONG"
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
       }
     ]
   },
@@ -206,16 +206,16 @@
     "example": "送別会を開きました。",
     "kanji_search_results": [
       {
-        "kanji": "会",
-        "mean": "HỘI, CỐI"
+        "kanji": "送",
+        "mean": "TỐNG"
       },
       {
         "kanji": "別",
         "mean": "BIỆT"
       },
       {
-        "kanji": "送",
-        "mean": "TỐNG"
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
       }
     ]
   },
@@ -230,16 +230,16 @@
     "example": "国際結婚をしました。",
     "kanji_search_results": [
       {
+        "kanji": "国",
+        "mean": "QUỐC"
+      },
+      {
         "kanji": "際",
         "mean": "TẾ"
       },
       {
         "kanji": "結",
         "mean": "KẾT"
-      },
-      {
-        "kanji": "国",
-        "mean": "QUỐC"
       },
       {
         "kanji": "婚",
@@ -278,12 +278,12 @@
     "example": "日本に留学しています。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "留",
         "mean": "LƯU"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       }
     ]
   },
@@ -378,12 +378,12 @@
     "example": "気持ちがいいです。",
     "kanji_search_results": [
       {
-        "kanji": "持",
-        "mean": "TRÌ"
-      },
-      {
         "kanji": "気",
         "mean": "KHÍ"
+      },
+      {
+        "kanji": "持",
+        "mean": "TRÌ"
       }
     ]
   },
@@ -630,12 +630,12 @@
     "example": "勉強が必要です。",
     "kanji_search_results": [
       {
-        "kanji": "要",
-        "mean": "YẾU, YÊU"
-      },
-      {
         "kanji": "必",
         "mean": "TẤT"
+      },
+      {
+        "kanji": "要",
+        "mean": "YẾU, YÊU"
       }
     ]
   },
@@ -746,16 +746,16 @@
     "example": "丁寧形で話してください。",
     "kanji_search_results": [
       {
+        "kanji": "丁",
+        "mean": "ĐINH, CHÊNH, TRANH"
+      },
+      {
         "kanji": "寧",
         "mean": "NINH, TRỮ"
       },
       {
         "kanji": "形",
         "mean": "HÌNH"
-      },
-      {
-        "kanji": "丁",
-        "mean": "ĐINH, CHÊNH, TRANH"
       }
     ]
   },
@@ -774,12 +774,12 @@
         "mean": "PHỔ"
       },
       {
-        "kanji": "形",
-        "mean": "HÌNH"
-      },
-      {
         "kanji": "通",
         "mean": "THÔNG"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
       }
     ]
   }

--- a/data/lesson_19_vocabulary.json
+++ b/data/lesson_19_vocabulary.json
@@ -7,7 +7,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "nature",
-    "example": "地球を守りましょう。"
+    "example": "地球を守りましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "球",
+        "mean": "CẦU"
+      },
+      {
+        "kanji": "地",
+        "mean": "ĐỊA"
+      }
+    ]
   },
   {
     "japanese": "じんこう",
@@ -17,7 +27,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "society",
-    "example": "人口が増えています。"
+    "example": "人口が増えています。",
+    "kanji_search_results": [
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "つき",
@@ -27,7 +47,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "月がきれいです。"
+    "example": "月がきれいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "しゅるい",
@@ -37,7 +63,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "種類がたくさんあります。"
+    "example": "種類がたくさんあります。",
+    "kanji_search_results": [
+      {
+        "kanji": "種",
+        "mean": "CHỦNG, CHÚNG"
+      },
+      {
+        "kanji": "類",
+        "mean": "LOẠI"
+      }
+    ]
   },
   {
     "japanese": "いしゃ",
@@ -47,7 +83,17 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "person",
-    "example": "医者に診てもらいました。"
+    "example": "医者に診てもらいました。",
+    "kanji_search_results": [
+      {
+        "kanji": "医",
+        "mean": "Y"
+      },
+      {
+        "kanji": "者",
+        "mean": "GIẢ"
+      }
+    ]
   },
   {
     "japanese": "かぜ",
@@ -57,7 +103,17 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "health",
-    "example": "風邪をひきました。"
+    "example": "風邪をひきました。",
+    "kanji_search_results": [
+      {
+        "kanji": "風",
+        "mean": "PHONG"
+      },
+      {
+        "kanji": "邪",
+        "mean": "TÀ, DA"
+      }
+    ]
   },
   {
     "japanese": "インフルエンザ",
@@ -77,7 +133,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "health",
-    "example": "薬を飲みました。"
+    "example": "薬を飲みました。",
+    "kanji_search_results": [
+      {
+        "kanji": "薬",
+        "mean": "DƯỢC"
+      }
+    ]
   },
   {
     "japanese": "ようじ",
@@ -87,7 +149,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "work",
-    "example": "用事があります。"
+    "example": "用事があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      },
+      {
+        "kanji": "用",
+        "mean": "DỤNG"
+      }
+    ]
   },
   {
     "japanese": "ぼうねんかい",
@@ -97,7 +169,21 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "event",
-    "example": "忘年会に参加しました。"
+    "example": "忘年会に参加しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      },
+      {
+        "kanji": "忘",
+        "mean": "VONG"
+      }
+    ]
   },
   {
     "japanese": "ミーティング",
@@ -117,7 +203,21 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "event",
-    "example": "送別会を開きました。"
+    "example": "送別会を開きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "別",
+        "mean": "BIỆT"
+      },
+      {
+        "kanji": "送",
+        "mean": "TỐNG"
+      }
+    ]
   },
   {
     "japanese": "こくさいけっこん",
@@ -127,7 +227,25 @@
     "lesson": 19,
     "difficulty": "advanced",
     "category": "society",
-    "example": "国際結婚をしました。"
+    "example": "国際結婚をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "際",
+        "mean": "TẾ"
+      },
+      {
+        "kanji": "結",
+        "mean": "KẾT"
+      },
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      },
+      {
+        "kanji": "婚",
+        "mean": "HÔN"
+      }
+    ]
   },
   {
     "japanese": "しゅうかん",
@@ -137,7 +255,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "良い習慣を身につけましょう。"
+    "example": "良い習慣を身につけましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "習",
+        "mean": "TẬP"
+      },
+      {
+        "kanji": "慣",
+        "mean": "QUÁN"
+      }
+    ]
   },
   {
     "japanese": "りゅうがく",
@@ -147,7 +275,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "日本に留学しています。"
+    "example": "日本に留学しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "留",
+        "mean": "LƯU"
+      }
+    ]
   },
   {
     "japanese": "はれ",
@@ -157,7 +295,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "weather",
-    "example": "今日は晴れです。"
+    "example": "今日は晴れです。",
+    "kanji_search_results": [
+      {
+        "kanji": "晴",
+        "mean": "TÌNH"
+      }
+    ]
   },
   {
     "japanese": "くもり",
@@ -167,7 +311,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "weather",
-    "example": "明日は曇りです。"
+    "example": "明日は曇りです。",
+    "kanji_search_results": [
+      {
+        "kanji": "曇",
+        "mean": "ĐÀM"
+      }
+    ]
   },
   {
     "japanese": "もり",
@@ -177,7 +327,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "森を散歩しました。"
+    "example": "森を散歩しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "森",
+        "mean": "SÂM"
+      }
+    ]
   },
   {
     "japanese": "かわ",
@@ -187,7 +343,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "川で魚を釣りました。"
+    "example": "川で魚を釣りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "川",
+        "mean": "XUYÊN"
+      }
+    ]
   },
   {
     "japanese": "みなと",
@@ -197,7 +359,13 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "港に船が着きました。"
+    "example": "港に船が着きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "港",
+        "mean": "CẢNG"
+      }
+    ]
   },
   {
     "japanese": "きもち",
@@ -207,7 +375,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "気持ちがいいです。"
+    "example": "気持ちがいいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "持",
+        "mean": "TRÌ"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      }
+    ]
   },
   {
     "japanese": "ラッシュアワー",
@@ -237,7 +415,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "time",
-    "example": "昔のことを思い出しました。"
+    "example": "昔のことを思い出しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "昔",
+        "mean": "TÍCH"
+      }
+    ]
   },
   {
     "japanese": "そう",
@@ -257,7 +441,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "そう思います。"
+    "example": "そう思います。",
+    "kanji_search_results": [
+      {
+        "kanji": "思",
+        "mean": "TƯ, TỨ, TAI"
+      }
+    ]
   },
   {
     "japanese": "ふえる",
@@ -267,7 +457,13 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "人口が増えています。"
+    "example": "人口が増えています。",
+    "kanji_search_results": [
+      {
+        "kanji": "増",
+        "mean": "TĂNG"
+      }
+    ]
   },
   {
     "japanese": "へる",
@@ -277,7 +473,13 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "体重が減りました。"
+    "example": "体重が減りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "減",
+        "mean": "GIẢM"
+      }
+    ]
   },
   {
     "japanese": "なくなる",
@@ -297,7 +499,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "風邪が治りました。"
+    "example": "風邪が治りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "治",
+        "mean": "TRÌ, TRỊ"
+      }
+    ]
   },
   {
     "japanese": "のむ",
@@ -307,7 +515,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "薬を飲んでください。"
+    "example": "薬を飲んでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "飲",
+        "mean": "ẨM, ẤM"
+      }
+    ]
   },
   {
     "japanese": "でる",
@@ -317,7 +531,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "会議に出ました。"
+    "example": "会議に出ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "出",
+        "mean": "XUẤT, XÚY"
+      }
+    ]
   },
   {
     "japanese": "ちがう",
@@ -327,7 +547,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "答えが違います。"
+    "example": "答えが違います。",
+    "kanji_search_results": [
+      {
+        "kanji": "違",
+        "mean": "VI"
+      }
+    ]
   },
   {
     "japanese": "あるく",
@@ -337,7 +563,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "公園を歩きました。"
+    "example": "公園を歩きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "歩",
+        "mean": "BỘ"
+      }
+    ]
   },
   {
     "japanese": "みえる",
@@ -347,7 +579,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "富士山が見えます。"
+    "example": "富士山が見えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "つかれる",
@@ -357,7 +595,13 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "仕事で疲れました。"
+    "example": "仕事で疲れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "疲",
+        "mean": "BÌ"
+      }
+    ]
   },
   {
     "japanese": "きびしい",
@@ -367,7 +611,13 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "先生が厳しいです。"
+    "example": "先生が厳しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "厳",
+        "mean": "NGHIÊM"
+      }
+    ]
   },
   {
     "japanese": "ひつよう",
@@ -377,7 +627,17 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "勉強が必要です。"
+    "example": "勉強が必要です。",
+    "kanji_search_results": [
+      {
+        "kanji": "要",
+        "mean": "YẾU, YÊU"
+      },
+      {
+        "kanji": "必",
+        "mean": "TẤT"
+      }
+    ]
   },
   {
     "japanese": "これから",
@@ -447,7 +707,17 @@
     "lesson": 19,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "お大事にしてください。"
+    "example": "お大事にしてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "こんで います",
@@ -457,7 +727,13 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "電車が込んでいます。"
+    "example": "電車が込んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "込",
+        "mean": ""
+      }
+    ]
   },
   {
     "japanese": "ていねいけい",
@@ -467,7 +743,21 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "丁寧形で話してください。"
+    "example": "丁寧形で話してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "寧",
+        "mean": "NINH, TRỮ"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "丁",
+        "mean": "ĐINH, CHÊNH, TRANH"
+      }
+    ]
   },
   {
     "japanese": "ふつうけい",
@@ -477,6 +767,20 @@
     "lesson": 19,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "普通形で話してもいいです。"
+    "example": "普通形で話してもいいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "普",
+        "mean": "PHỔ"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "通",
+        "mean": "THÔNG"
+      }
+    ]
   }
 ]

--- a/data/lesson_1_vocabulary.json
+++ b/data/lesson_1_vocabulary.json
@@ -88,16 +88,16 @@
     "example": "銀行員をしています。",
     "kanji_search_results": [
       {
-        "kanji": "員",
-        "mean": "VIÊN, VÂN"
+        "kanji": "銀",
+        "mean": "NGÂN"
       },
       {
         "kanji": "行",
         "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       },
       {
-        "kanji": "銀",
-        "mean": "NGÂN"
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
       }
     ]
   },
@@ -112,16 +112,16 @@
     "example": "会社員です。",
     "kanji_search_results": [
       {
-        "kanji": "員",
-        "mean": "VIÊN, VÂN"
-      },
-      {
         "kanji": "会",
         "mean": "HỘI, CỐI"
       },
       {
         "kanji": "社",
         "mean": "XÃ"
+      },
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
       }
     ]
   },
@@ -160,12 +160,12 @@
         "mean": "NGHIÊN"
       },
       {
-        "kanji": "員",
-        "mean": "VIÊN, VÂN"
-      },
-      {
         "kanji": "究",
         "mean": "CỨU"
+      },
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
       }
     ]
   },
@@ -180,6 +180,14 @@
     "example": "日本語学校で勉強しています。",
     "kanji_search_results": [
       {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      },
+      {
         "kanji": "語",
         "mean": "NGỮ, NGỨ"
       },
@@ -188,16 +196,8 @@
         "mean": "HỌC"
       },
       {
-        "kanji": "本",
-        "mean": "BỔN, BẢN"
-      },
-      {
         "kanji": "校",
         "mean": "GIÁO, HIỆU, HÀO"
-      },
-      {
-        "kanji": "日",
-        "mean": "NHẬT, NHỰT"
       }
     ]
   },
@@ -212,12 +212,12 @@
     "example": "大学で経済を勉強しています。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "大",
         "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       }
     ]
   },
@@ -292,12 +292,12 @@
     "example": "お名前は何ですか。",
     "kanji_search_results": [
       {
-        "kanji": "前",
-        "mean": "TIỀN"
-      },
-      {
         "kanji": "名",
         "mean": "DANH"
+      },
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
       }
     ]
   },
@@ -348,12 +348,12 @@
     "example": "水泳が好きです。",
     "kanji_search_results": [
       {
-        "kanji": "泳",
-        "mean": "VỊNH"
-      },
-      {
         "kanji": "水",
         "mean": "THỦY"
+      },
+      {
+        "kanji": "泳",
+        "mean": "VỊNH"
       }
     ]
   },
@@ -486,12 +486,12 @@
     "example": "お名前は何ですか。",
     "kanji_search_results": [
       {
-        "kanji": "前",
-        "mean": "TIỀN"
-      },
-      {
         "kanji": "名",
         "mean": "DANH"
+      },
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
       }
     ]
   },
@@ -628,12 +628,12 @@
     "example": "日本に住んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "本",
-        "mean": "BỔN, BẢN"
-      },
-      {
         "kanji": "日",
         "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
       }
     ]
   },
@@ -658,12 +658,12 @@
     "example": "韓国人です。",
     "kanji_search_results": [
       {
-        "kanji": "国",
-        "mean": "QUỐC"
-      },
-      {
         "kanji": "韓",
         "mean": "HÀN"
+      },
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
       }
     ]
   },

--- a/data/lesson_1_vocabulary.json
+++ b/data/lesson_1_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "pronoun",
-    "example": "わたしは学生です。"
+    "example": "わたしは学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "私",
+        "mean": "TƯ"
+      }
+    ]
   },
   {
     "japanese": "がくせい",
@@ -17,7 +23,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "私は学生です。"
+    "example": "私は学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "～じん",
@@ -27,7 +43,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "ベトナム人です。"
+    "example": "ベトナム人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "エンジニア",
@@ -47,7 +69,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "銀行員です。"
+    "example": "銀行員です。",
+    "kanji_search_results": [
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
+      }
+    ]
   },
   {
     "japanese": "ぎんこういん",
@@ -57,7 +85,21 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "銀行員をしています。"
+    "example": "銀行員をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
+      },
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "銀",
+        "mean": "NGÂN"
+      }
+    ]
   },
   {
     "japanese": "かいしゃいん",
@@ -67,7 +109,21 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "会社員です。"
+    "example": "会社員です。",
+    "kanji_search_results": [
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "社",
+        "mean": "XÃ"
+      }
+    ]
   },
   {
     "japanese": "せんせい",
@@ -77,7 +133,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "田中先生です。"
+    "example": "田中先生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "けんきゅういん",
@@ -87,7 +153,21 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "研究員として働いています。"
+    "example": "研究員として働いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "研",
+        "mean": "NGHIÊN"
+      },
+      {
+        "kanji": "員",
+        "mean": "VIÊN, VÂN"
+      },
+      {
+        "kanji": "究",
+        "mean": "CỨU"
+      }
+    ]
   },
   {
     "japanese": "にほんごがっこう",
@@ -97,7 +177,29 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "place",
-    "example": "日本語学校で勉強しています。"
+    "example": "日本語学校で勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "語",
+        "mean": "NGỮ, NGỨ"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "だいがく",
@@ -107,7 +209,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "place",
-    "example": "大学で経済を勉強しています。"
+    "example": "大学で経済を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   },
   {
     "japanese": "りょう",
@@ -117,7 +229,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "place",
-    "example": "寮に住んでいます。"
+    "example": "寮に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "寮",
+        "mean": "LIÊU"
+      }
+    ]
   },
   {
     "japanese": "かんりにん",
@@ -127,7 +245,21 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "occupation",
-    "example": "寮の管理人です。"
+    "example": "寮の管理人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "管",
+        "mean": "QUẢN"
+      },
+      {
+        "kanji": "理",
+        "mean": "LÍ"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "がっこう",
@@ -137,7 +269,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "place",
-    "example": "学校はどこですか。"
+    "example": "学校はどこですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      }
+    ]
   },
   {
     "japanese": "なまえ",
@@ -147,7 +289,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "personal_info",
-    "example": "お名前は何ですか。"
+    "example": "お名前は何ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      }
+    ]
   },
   {
     "japanese": "くに",
@@ -157,7 +309,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "personal_info",
-    "example": "お国はどちらですか。"
+    "example": "お国はどちらですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      }
+    ]
   },
   {
     "japanese": "しゅみ",
@@ -167,7 +325,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "personal_info",
-    "example": "趣味は何ですか。"
+    "example": "趣味は何ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "趣",
+        "mean": "THÚ, XÚC"
+      },
+      {
+        "kanji": "味",
+        "mean": "VỊ"
+      }
+    ]
   },
   {
     "japanese": "すいえい",
@@ -177,7 +345,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "hobby",
-    "example": "水泳が好きです。"
+    "example": "水泳が好きです。",
+    "kanji_search_results": [
+      {
+        "kanji": "泳",
+        "mean": "VỊNH"
+      },
+      {
+        "kanji": "水",
+        "mean": "THỦY"
+      }
+    ]
   },
   {
     "japanese": "ともだち",
@@ -187,7 +365,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "relationship",
-    "example": "友達と映画を見ました。"
+    "example": "友達と映画を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "友",
+        "mean": "HỮU"
+      },
+      {
+        "kanji": "達",
+        "mean": "ĐẠT"
+      }
+    ]
   },
   {
     "japanese": "はい",
@@ -237,7 +425,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "greeting",
-    "example": "はじめまして。田中です。"
+    "example": "はじめまして。田中です。",
+    "kanji_search_results": [
+      {
+        "kanji": "初",
+        "mean": "SƠ"
+      }
+    ]
   },
   {
     "japanese": "どうぞ よろしく おねがいします",
@@ -247,7 +441,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "greeting",
-    "example": "はじめまして。どうぞよろしくお願いします。"
+    "example": "はじめまして。どうぞよろしくお願いします。",
+    "kanji_search_results": [
+      {
+        "kanji": "願",
+        "mean": "NGUYỆN"
+      }
+    ]
   },
   {
     "japanese": "こちらこそ どうぞ よろしく おねがいします",
@@ -257,7 +457,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "greeting",
-    "example": "こちらこそ、どうぞよろしくお願いします。"
+    "example": "こちらこそ、どうぞよろしくお願いします。",
+    "kanji_search_results": [
+      {
+        "kanji": "願",
+        "mean": "NGUYỆN"
+      }
+    ]
   },
   {
     "japanese": "すみません",
@@ -277,7 +483,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "question",
-    "example": "お名前は何ですか。"
+    "example": "お名前は何ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      }
+    ]
   },
   {
     "japanese": "おくには どちらですか",
@@ -287,7 +503,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "question",
-    "example": "お国はどちらですか。"
+    "example": "お国はどちらですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      }
+    ]
   },
   {
     "japanese": "～から きました",
@@ -297,7 +519,13 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "response",
-    "example": "ベトナムから来ました。"
+    "example": "ベトナムから来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      }
+    ]
   },
   {
     "japanese": "～は",
@@ -327,7 +555,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "country",
-    "example": "中国から来ました。"
+    "example": "中国から来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      },
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      }
+    ]
   },
   {
     "japanese": "ペルー",
@@ -387,7 +625,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "country",
-    "example": "日本に住んでいます。"
+    "example": "日本に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "アメリカ",
@@ -407,7 +655,17 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "country",
-    "example": "韓国人です。"
+    "example": "韓国人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "国",
+        "mean": "QUỐC"
+      },
+      {
+        "kanji": "韓",
+        "mean": "HÀN"
+      }
+    ]
   },
   {
     "japanese": "つかいましょう",
@@ -417,6 +675,12 @@
     "lesson": 1,
     "difficulty": "beginner",
     "category": "instruction",
-    "example": "この辞書を使いましょう。"
+    "example": "この辞書を使いましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "使",
+        "mean": "SỬ, SỨ"
+      }
+    ]
   }
 ]

--- a/data/lesson_20_vocabulary.json
+++ b/data/lesson_20_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "火を消してください。"
+    "example": "火を消してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "火",
+        "mean": "HỎA"
+      }
+    ]
   },
   {
     "japanese": "きけん",
@@ -17,7 +23,17 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "危険な場所です。"
+    "example": "危険な場所です。",
+    "kanji_search_results": [
+      {
+        "kanji": "危",
+        "mean": "NGUY"
+      },
+      {
+        "kanji": "険",
+        "mean": "HIỂM"
+      }
+    ]
   },
   {
     "japanese": "うちゅう",
@@ -27,7 +43,17 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "science",
-    "example": "宇宙を研究しています。"
+    "example": "宇宙を研究しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "宙",
+        "mean": "TRỤ"
+      },
+      {
+        "kanji": "宇",
+        "mean": "VŨ"
+      }
+    ]
   },
   {
     "japanese": "うちゅうステーション",
@@ -37,7 +63,17 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "science",
-    "example": "宇宙ステーションにいます。"
+    "example": "宇宙ステーションにいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "宙",
+        "mean": "TRỤ"
+      },
+      {
+        "kanji": "宇",
+        "mean": "VŨ"
+      }
+    ]
   },
   {
     "japanese": "ゆめ",
@@ -47,7 +83,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "abstract",
-    "example": "夢を見ました。"
+    "example": "夢を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "夢",
+        "mean": "MỘNG, MÔNG"
+      }
+    ]
   },
   {
     "japanese": "かがくしゃ",
@@ -57,7 +99,21 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "person",
-    "example": "科学者になりたいです。"
+    "example": "科学者になりたいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "科",
+        "mean": "KHOA"
+      },
+      {
+        "kanji": "者",
+        "mean": "GIẢ"
+      }
+    ]
   },
   {
     "japanese": "じっけん",
@@ -67,7 +123,17 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "science",
-    "example": "実験をしました。"
+    "example": "実験をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "験",
+        "mean": "NGHIỆM"
+      },
+      {
+        "kanji": "実",
+        "mean": "THỰC"
+      }
+    ]
   },
   {
     "japanese": "バイオぎじゅつ",
@@ -77,7 +143,17 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "science",
-    "example": "バイオ技術を勉強しています。"
+    "example": "バイオ技術を勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "術",
+        "mean": "THUẬT"
+      },
+      {
+        "kanji": "技",
+        "mean": "KĨ"
+      }
+    ]
   },
   {
     "japanese": "ビル",
@@ -107,7 +183,17 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "clothing",
-    "example": "帽子をかぶりました。"
+    "example": "帽子をかぶりました。",
+    "kanji_search_results": [
+      {
+        "kanji": "帽",
+        "mean": "MẠO"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "スカート",
@@ -127,7 +213,17 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "clothing",
-    "example": "眼鏡をかけました。"
+    "example": "眼鏡をかけました。",
+    "kanji_search_results": [
+      {
+        "kanji": "鏡",
+        "mean": "KÍNH"
+      },
+      {
+        "kanji": "眼",
+        "mean": "NHÃN"
+      }
+    ]
   },
   {
     "japanese": "かみ",
@@ -137,7 +233,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "item",
-    "example": "紙に書いてください。"
+    "example": "紙に書いてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "紙",
+        "mean": "CHỈ"
+      }
+    ]
   },
   {
     "japanese": "はさみ",
@@ -187,7 +289,17 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "運動をしています。"
+    "example": "運動をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
+      },
+      {
+        "kanji": "運",
+        "mean": "VẬN"
+      }
+    ]
   },
   {
     "japanese": "シート",
@@ -207,7 +319,13 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "その他に何かありますか。"
+    "example": "その他に何かありますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "他",
+        "mean": "THA"
+      }
+    ]
   },
   {
     "japanese": "こわす",
@@ -217,7 +335,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "おもちゃを壊しました。"
+    "example": "おもちゃを壊しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "壊",
+        "mean": "HOẠI"
+      }
+    ]
   },
   {
     "japanese": "しらせる",
@@ -227,7 +351,13 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "結果を知らせました。"
+    "example": "結果を知らせました。",
+    "kanji_search_results": [
+      {
+        "kanji": "知",
+        "mean": "TRI, TRÍ"
+      }
+    ]
   },
   {
     "japanese": "せっけいする",
@@ -237,7 +367,17 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "verb",
-    "example": "建物を設計しました。"
+    "example": "建物を設計しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "設",
+        "mean": "THIẾT"
+      },
+      {
+        "kanji": "計",
+        "mean": "KẾ, KÊ"
+      }
+    ]
   },
   {
     "japanese": "うまれる",
@@ -247,7 +387,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "赤ちゃんが生まれました。"
+    "example": "赤ちゃんが生まれました。",
+    "kanji_search_results": [
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "そだてる",
@@ -257,7 +403,13 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "子供を育てています。"
+    "example": "子供を育てています。",
+    "kanji_search_results": [
+      {
+        "kanji": "育",
+        "mean": "DỤC"
+      }
+    ]
   },
   {
     "japanese": "かぶる",
@@ -277,7 +429,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "眼鏡をかけました。"
+    "example": "眼鏡をかけました。",
+    "kanji_search_results": [
+      {
+        "kanji": "掛",
+        "mean": "QUẢI"
+      }
+    ]
   },
   {
     "japanese": "する",
@@ -297,7 +455,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "時間を決めました。"
+    "example": "時間を決めました。",
+    "kanji_search_results": [
+      {
+        "kanji": "決",
+        "mean": "QUYẾT"
+      }
+    ]
   },
   {
     "japanese": "まとめる",
@@ -317,7 +481,13 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "counter",
-    "example": "ビールを三本飲みました。"
+    "example": "ビールを三本飲みました。",
+    "kanji_search_results": [
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      }
+    ]
   },
   {
     "japanese": "なんぼん",
@@ -327,7 +497,17 @@
     "lesson": 20,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何本ありますか。"
+    "example": "何本ありますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      }
+    ]
   },
   {
     "japanese": "ゆうべ",
@@ -367,7 +547,17 @@
     "lesson": 20,
     "difficulty": "intermediate",
     "category": "expression",
-    "example": "以上です。ありがとうございました。"
+    "example": "以上です。ありがとうございました。",
+    "kanji_search_results": [
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      },
+      {
+        "kanji": "以",
+        "mean": "DĨ"
+      }
+    ]
   },
   {
     "japanese": "まあ",
@@ -417,7 +607,21 @@
     "lesson": 20,
     "difficulty": "advanced",
     "category": "person",
-    "example": "紫式部は源氏物語を書きました。"
+    "example": "紫式部は源氏物語を書きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "部",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "紫",
+        "mean": "TỬ"
+      },
+      {
+        "kanji": "式",
+        "mean": "THỨC"
+      }
+    ]
   },
   {
     "japanese": "ナポレオン",

--- a/data/lesson_20_vocabulary.json
+++ b/data/lesson_20_vocabulary.json
@@ -46,12 +46,12 @@
     "example": "宇宙を研究しています。",
     "kanji_search_results": [
       {
-        "kanji": "宙",
-        "mean": "TRỤ"
-      },
-      {
         "kanji": "宇",
         "mean": "VŨ"
+      },
+      {
+        "kanji": "宙",
+        "mean": "TRỤ"
       }
     ]
   },
@@ -66,12 +66,12 @@
     "example": "宇宙ステーションにいます。",
     "kanji_search_results": [
       {
-        "kanji": "宙",
-        "mean": "TRỤ"
-      },
-      {
         "kanji": "宇",
         "mean": "VŨ"
+      },
+      {
+        "kanji": "宙",
+        "mean": "TRỤ"
       }
     ]
   },
@@ -102,12 +102,12 @@
     "example": "科学者になりたいです。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "科",
         "mean": "KHOA"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       },
       {
         "kanji": "者",
@@ -126,12 +126,12 @@
     "example": "実験をしました。",
     "kanji_search_results": [
       {
-        "kanji": "験",
-        "mean": "NGHIỆM"
-      },
-      {
         "kanji": "実",
         "mean": "THỰC"
+      },
+      {
+        "kanji": "験",
+        "mean": "NGHIỆM"
       }
     ]
   },
@@ -146,12 +146,12 @@
     "example": "バイオ技術を勉強しています。",
     "kanji_search_results": [
       {
-        "kanji": "術",
-        "mean": "THUẬT"
-      },
-      {
         "kanji": "技",
         "mean": "KĨ"
+      },
+      {
+        "kanji": "術",
+        "mean": "THUẬT"
       }
     ]
   },
@@ -216,12 +216,12 @@
     "example": "眼鏡をかけました。",
     "kanji_search_results": [
       {
-        "kanji": "鏡",
-        "mean": "KÍNH"
-      },
-      {
         "kanji": "眼",
         "mean": "NHÃN"
+      },
+      {
+        "kanji": "鏡",
+        "mean": "KÍNH"
       }
     ]
   },
@@ -292,12 +292,12 @@
     "example": "運動をしています。",
     "kanji_search_results": [
       {
-        "kanji": "動",
-        "mean": "ĐỘNG"
-      },
-      {
         "kanji": "運",
         "mean": "VẬN"
+      },
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
       }
     ]
   },
@@ -550,12 +550,12 @@
     "example": "以上です。ありがとうございました。",
     "kanji_search_results": [
       {
-        "kanji": "上",
-        "mean": "THƯỢNG, THƯỚNG"
-      },
-      {
         "kanji": "以",
         "mean": "DĨ"
+      },
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
       }
     ]
   },
@@ -610,16 +610,16 @@
     "example": "紫式部は源氏物語を書きました。",
     "kanji_search_results": [
       {
-        "kanji": "部",
-        "mean": "BỘ"
-      },
-      {
         "kanji": "紫",
         "mean": "TỬ"
       },
       {
         "kanji": "式",
         "mean": "THỨC"
+      },
+      {
+        "kanji": "部",
+        "mean": "BỘ"
       }
     ]
   },

--- a/data/lesson_21_vocabulary.json
+++ b/data/lesson_21_vocabulary.json
@@ -26,12 +26,12 @@
     "example": "残業をしました。",
     "kanji_search_results": [
       {
-        "kanji": "業",
-        "mean": "NGHIỆP"
-      },
-      {
         "kanji": "残",
         "mean": "TÀN"
+      },
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
       }
     ]
   },
@@ -112,12 +112,12 @@
     "example": "事故に遭いました。",
     "kanji_search_results": [
       {
-        "kanji": "故",
-        "mean": "CỐ"
-      },
-      {
         "kanji": "事",
         "mean": "SỰ"
+      },
+      {
+        "kanji": "故",
+        "mean": "CỐ"
       }
     ]
   },
@@ -140,12 +140,12 @@
         "mean": "THÔNG"
       },
       {
-        "kanji": "故",
-        "mean": "CỐ"
-      },
-      {
         "kanji": "事",
         "mean": "SỰ"
+      },
+      {
+        "kanji": "故",
+        "mean": "CỐ"
       }
     ]
   },
@@ -180,12 +180,12 @@
     "example": "台風が来ています。",
     "kanji_search_results": [
       {
-        "kanji": "風",
-        "mean": "PHONG"
-      },
-      {
         "kanji": "台",
         "mean": "THAI, ĐÀI, DI"
+      },
+      {
+        "kanji": "風",
+        "mean": "PHONG"
       }
     ]
   },
@@ -200,12 +200,12 @@
     "example": "警察に連絡しました。",
     "kanji_search_results": [
       {
-        "kanji": "察",
-        "mean": "SÁT"
-      },
-      {
         "kanji": "警",
         "mean": "CẢNH"
+      },
+      {
+        "kanji": "察",
+        "mean": "SÁT"
       }
     ]
   },
@@ -254,12 +254,12 @@
         "mean": "THỤ"
       },
       {
-        "kanji": "票",
-        "mean": "PHIẾU, TIÊU, PHIÊU"
-      },
-      {
         "kanji": "験",
         "mean": "NGHIỆM"
+      },
+      {
+        "kanji": "票",
+        "mean": "PHIẾU, TIÊU, PHIÊU"
       }
     ]
   },
@@ -308,12 +308,12 @@
     "example": "成績が良かったです。",
     "kanji_search_results": [
       {
-        "kanji": "績",
-        "mean": "TÍCH"
-      },
-      {
         "kanji": "成",
         "mean": "THÀNH"
+      },
+      {
+        "kanji": "績",
+        "mean": "TÍCH"
       }
     ]
   },
@@ -498,12 +498,12 @@
         "mean": "THÂN"
       },
       {
-        "kanji": "書",
-        "mean": "THƯ"
-      },
-      {
         "kanji": "込",
         "mean": ""
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
       }
     ]
   },
@@ -988,12 +988,12 @@
     "example": "心配です。",
     "kanji_search_results": [
       {
-        "kanji": "配",
-        "mean": "PHỐI"
-      },
-      {
         "kanji": "心",
         "mean": "TÂM"
+      },
+      {
+        "kanji": "配",
+        "mean": "PHỐI"
       }
     ]
   },
@@ -1008,12 +1008,12 @@
     "example": "四人乗りの車です。",
     "kanji_search_results": [
       {
-        "kanji": "乗",
-        "mean": "THỪA"
-      },
-      {
         "kanji": "人",
         "mean": "NHÂN"
+      },
+      {
+        "kanji": "乗",
+        "mean": "THỪA"
       }
     ]
   },
@@ -1048,12 +1048,12 @@
     "example": "十八歳以上です。",
     "kanji_search_results": [
       {
-        "kanji": "上",
-        "mean": "THƯỢNG, THƯỚNG"
-      },
-      {
         "kanji": "以",
         "mean": "DĨ"
+      },
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
       }
     ]
   },

--- a/data/lesson_21_vocabulary.json
+++ b/data/lesson_21_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "weather",
-    "example": "雪が降っています。"
+    "example": "雪が降っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "雪",
+        "mean": "TUYẾT"
+      }
+    ]
   },
   {
     "japanese": "ざんぎょう",
@@ -17,7 +23,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "work",
-    "example": "残業をしました。"
+    "example": "残業をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "業",
+        "mean": "NGHIỆP"
+      },
+      {
+        "kanji": "残",
+        "mean": "TÀN"
+      }
+    ]
   },
   {
     "japanese": "びょうき",
@@ -27,7 +43,17 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "health",
-    "example": "病気になりました。"
+    "example": "病気になりました。",
+    "kanji_search_results": [
+      {
+        "kanji": "病",
+        "mean": "BỆNH"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      }
+    ]
   },
   {
     "japanese": "みち",
@@ -37,7 +63,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "place",
-    "example": "道を歩きました。"
+    "example": "道を歩きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "道",
+        "mean": "ĐẠO, ĐÁO"
+      }
+    ]
   },
   {
     "japanese": "キャッシュカード",
@@ -57,7 +89,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "transport",
-    "example": "交通が便利です。"
+    "example": "交通が便利です。",
+    "kanji_search_results": [
+      {
+        "kanji": "交",
+        "mean": "GIAO"
+      },
+      {
+        "kanji": "通",
+        "mean": "THÔNG"
+      }
+    ]
   },
   {
     "japanese": "じこ",
@@ -67,7 +109,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "incident",
-    "example": "事故に遭いました。"
+    "example": "事故に遭いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "故",
+        "mean": "CỐ"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "こうつうじこ",
@@ -77,7 +129,25 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "incident",
-    "example": "交通事故に気をつけてください。"
+    "example": "交通事故に気をつけてください。",
+    "kanji_search_results": [
+      {
+        "kanji": "交",
+        "mean": "GIAO"
+      },
+      {
+        "kanji": "通",
+        "mean": "THÔNG"
+      },
+      {
+        "kanji": "故",
+        "mean": "CỐ"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "じしん",
@@ -87,7 +157,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "disaster",
-    "example": "地震が起きました。"
+    "example": "地震が起きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "地",
+        "mean": "ĐỊA"
+      },
+      {
+        "kanji": "震",
+        "mean": "CHẤN"
+      }
+    ]
   },
   {
     "japanese": "たいふう",
@@ -97,7 +177,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "disaster",
-    "example": "台風が来ています。"
+    "example": "台風が来ています。",
+    "kanji_search_results": [
+      {
+        "kanji": "風",
+        "mean": "PHONG"
+      },
+      {
+        "kanji": "台",
+        "mean": "THAI, ĐÀI, DI"
+      }
+    ]
   },
   {
     "japanese": "けいさつ",
@@ -107,7 +197,17 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "person",
-    "example": "警察に連絡しました。"
+    "example": "警察に連絡しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "察",
+        "mean": "SÁT"
+      },
+      {
+        "kanji": "警",
+        "mean": "CẢNH"
+      }
+    ]
   },
   {
     "japanese": "エンジン",
@@ -127,7 +227,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "調子がいいです。"
+    "example": "調子がいいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "調",
+        "mean": "ĐIỀU, ĐIỆU"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "じゅけんひょう",
@@ -137,7 +247,21 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "受験票を忘れました。"
+    "example": "受験票を忘れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "受",
+        "mean": "THỤ"
+      },
+      {
+        "kanji": "票",
+        "mean": "PHIẾU, TIÊU, PHIÊU"
+      },
+      {
+        "kanji": "験",
+        "mean": "NGHIỆM"
+      }
+    ]
   },
   {
     "japanese": "あさねぼう",
@@ -147,7 +271,21 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "朝寝坊をしました。"
+    "example": "朝寝坊をしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
+      },
+      {
+        "kanji": "寝",
+        "mean": "TẨM"
+      },
+      {
+        "kanji": "坊",
+        "mean": "PHƯỜNG"
+      }
+    ]
   },
   {
     "japanese": "ラブレター",
@@ -167,7 +305,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "成績が良かったです。"
+    "example": "成績が良かったです。",
+    "kanji_search_results": [
+      {
+        "kanji": "績",
+        "mean": "TÍCH"
+      },
+      {
+        "kanji": "成",
+        "mean": "THÀNH"
+      }
+    ]
   },
   {
     "japanese": "おしゃべり",
@@ -187,7 +335,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "item",
-    "example": "図を見てください。"
+    "example": "図を見てください。",
+    "kanji_search_results": [
+      {
+        "kanji": "図",
+        "mean": "ĐỒ"
+      }
+    ]
   },
   {
     "japanese": "いえ",
@@ -197,7 +351,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "place",
-    "example": "家に帰りました。"
+    "example": "家に帰りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "家",
+        "mean": "GIA, CÔ"
+      }
+    ]
   },
   {
     "japanese": "ちから",
@@ -207,7 +367,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "abstract",
-    "example": "力が強いです。"
+    "example": "力が強いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "力",
+        "mean": "LỰC"
+      }
+    ]
   },
   {
     "japanese": "とし",
@@ -217,7 +383,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "time",
-    "example": "年をとりました。"
+    "example": "年をとりました。",
+    "kanji_search_results": [
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "おや",
@@ -227,7 +399,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "family",
-    "example": "親に相談しました。"
+    "example": "親に相談しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "親",
+        "mean": "THÂN, THẤN"
+      }
+    ]
   },
   {
     "japanese": "ふつう",
@@ -237,7 +415,17 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "普通の生活です。"
+    "example": "普通の生活です。",
+    "kanji_search_results": [
+      {
+        "kanji": "普",
+        "mean": "PHỔ"
+      },
+      {
+        "kanji": "通",
+        "mean": "THÔNG"
+      }
+    ]
   },
   {
     "japanese": "へび",
@@ -267,7 +455,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "申し込みをしました。"
+    "example": "申し込みをしました。",
+    "kanji_search_results": [
+      {
+        "kanji": "申",
+        "mean": "THÂN"
+      },
+      {
+        "kanji": "込",
+        "mean": ""
+      }
+    ]
   },
   {
     "japanese": "しょ",
@@ -277,7 +475,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "document",
-    "example": "申請書を書きました。"
+    "example": "申請書を書きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      }
+    ]
   },
   {
     "japanese": "もうしこみしょ",
@@ -287,7 +491,21 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "document",
-    "example": "申込書に記入しました。"
+    "example": "申込書に記入しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "申",
+        "mean": "THÂN"
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "込",
+        "mean": ""
+      }
+    ]
   },
   {
     "japanese": "ちゅうし",
@@ -297,7 +515,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "activity",
-    "example": "試合が中止になりました。"
+    "example": "試合が中止になりました。",
+    "kanji_search_results": [
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      },
+      {
+        "kanji": "止",
+        "mean": "CHỈ"
+      }
+    ]
   },
   {
     "japanese": "ふる",
@@ -307,7 +535,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "雨が降っています。"
+    "example": "雨が降っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "降",
+        "mean": "HÀNG, GIÁNG"
+      }
+    ]
   },
   {
     "japanese": "まよう",
@@ -317,7 +551,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "道に迷いました。"
+    "example": "道に迷いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "迷",
+        "mean": "MÊ"
+      }
+    ]
   },
   {
     "japanese": "なくす",
@@ -337,7 +577,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "事故に遭いました。"
+    "example": "事故に遭いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "遭",
+        "mean": "TAO"
+      }
+    ]
   },
   {
     "japanese": "おきる",
@@ -347,7 +593,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "事件が起きました。"
+    "example": "事件が起きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "起",
+        "mean": "KHỞI"
+      }
+    ]
   },
   {
     "japanese": "わすれる",
@@ -357,7 +609,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "約束を忘れました。"
+    "example": "約束を忘れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "忘",
+        "mean": "VONG"
+      }
+    ]
   },
   {
     "japanese": "ひろう",
@@ -367,7 +625,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お金を拾いました。"
+    "example": "お金を拾いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "拾",
+        "mean": "THẬP, THIỆP, KIỆP"
+      }
+    ]
   },
   {
     "japanese": "たりる",
@@ -377,7 +641,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "お金が足りません。"
+    "example": "お金が足りません。",
+    "kanji_search_results": [
+      {
+        "kanji": "足",
+        "mean": "TÚC"
+      }
+    ]
   },
   {
     "japanese": "つく",
@@ -387,7 +657,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "駅に着きました。"
+    "example": "駅に着きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "着",
+        "mean": "TRỨ, TRƯỚC, TRỮ"
+      }
+    ]
   },
   {
     "japanese": "とどく",
@@ -397,7 +673,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "荷物が届きました。"
+    "example": "荷物が届きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "届",
+        "mean": "GIỚI"
+      }
+    ]
   },
   {
     "japanese": "さく",
@@ -407,7 +689,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "花が咲きました。"
+    "example": "花が咲きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "咲",
+        "mean": "TIẾU"
+      }
+    ]
   },
   {
     "japanese": "しょうかいする",
@@ -417,7 +705,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "友達を紹介しました。"
+    "example": "友達を紹介しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "紹",
+        "mean": "THIỆU"
+      },
+      {
+        "kanji": "介",
+        "mean": "GIỚI"
+      }
+    ]
   },
   {
     "japanese": "やめる",
@@ -437,7 +735,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "家具を組み立てました。"
+    "example": "家具を組み立てました。",
+    "kanji_search_results": [
+      {
+        "kanji": "組",
+        "mean": "TỔ"
+      },
+      {
+        "kanji": "立",
+        "mean": "LẬP"
+      }
+    ]
   },
   {
     "japanese": "ふとる",
@@ -447,7 +755,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "太りました。"
+    "example": "太りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "太",
+        "mean": "THÁI"
+      }
+    ]
   },
   {
     "japanese": "やせる",
@@ -467,7 +781,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お金を落としました。"
+    "example": "お金を落としました。",
+    "kanji_search_results": [
+      {
+        "kanji": "落",
+        "mean": "LẠC"
+      }
+    ]
   },
   {
     "japanese": "われる",
@@ -477,7 +797,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "コップが割れました。"
+    "example": "コップが割れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "割",
+        "mean": "CÁT"
+      }
+    ]
   },
   {
     "japanese": "よう",
@@ -487,7 +813,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "お酒に酔いました。"
+    "example": "お酒に酔いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "酔",
+        "mean": "TÚY"
+      }
+    ]
   },
   {
     "japanese": "こわれる",
@@ -497,7 +829,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "テレビが壊れました。"
+    "example": "テレビが壊れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "壊",
+        "mean": "HOẠI"
+      }
+    ]
   },
   {
     "japanese": "ちゅういする",
@@ -507,7 +845,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "注意してください。"
+    "example": "注意してください。",
+    "kanji_search_results": [
+      {
+        "kanji": "注",
+        "mean": "CHÚ"
+      },
+      {
+        "kanji": "意",
+        "mean": "Ý"
+      }
+    ]
   },
   {
     "japanese": "けんかする",
@@ -527,7 +875,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "食べ物の好き嫌いをしないでください。"
+    "example": "食べ物の好き嫌いをしないでください。",
+    "kanji_search_results": [
+      {
+        "kanji": "好",
+        "mean": "HẢO, HIẾU"
+      },
+      {
+        "kanji": "嫌",
+        "mean": "HIỀM"
+      }
+    ]
   },
   {
     "japanese": "サボる",
@@ -547,7 +905,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "天気が悪いです。"
+    "example": "天気が悪いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "悪",
+        "mean": "ÁC"
+      }
+    ]
   },
   {
     "japanese": "よわい",
@@ -557,7 +921,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "体が弱いです。"
+    "example": "体が弱いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "弱",
+        "mean": "NHƯỢC"
+      }
+    ]
   },
   {
     "japanese": "つよい",
@@ -567,7 +937,13 @@
     "lesson": 21,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "力が強いです。"
+    "example": "力が強いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "強",
+        "mean": "CƯỜNG, CƯỠNG"
+      }
+    ]
   },
   {
     "japanese": "あまい",
@@ -577,7 +953,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "甘い親です。"
+    "example": "甘い親です。",
+    "kanji_search_results": [
+      {
+        "kanji": "甘",
+        "mean": "CAM"
+      }
+    ]
   },
   {
     "japanese": "しあわせ",
@@ -587,7 +969,13 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "幸せな生活です。"
+    "example": "幸せな生活です。",
+    "kanji_search_results": [
+      {
+        "kanji": "幸",
+        "mean": "HẠNH"
+      }
+    ]
   },
   {
     "japanese": "しんぱい",
@@ -597,7 +985,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "心配です。"
+    "example": "心配です。",
+    "kanji_search_results": [
+      {
+        "kanji": "配",
+        "mean": "PHỐI"
+      },
+      {
+        "kanji": "心",
+        "mean": "TÂM"
+      }
+    ]
   },
   {
     "japanese": "にんのり",
@@ -607,7 +1005,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "transport",
-    "example": "四人乗りの車です。"
+    "example": "四人乗りの車です。",
+    "kanji_search_results": [
+      {
+        "kanji": "乗",
+        "mean": "THỪA"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "いか",
@@ -617,7 +1025,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "comparison",
-    "example": "十八歳以下です。"
+    "example": "十八歳以下です。",
+    "kanji_search_results": [
+      {
+        "kanji": "以",
+        "mean": "DĨ"
+      },
+      {
+        "kanji": "下",
+        "mean": "HẠ, HÁ"
+      }
+    ]
   },
   {
     "japanese": "いじょう",
@@ -627,7 +1045,17 @@
     "lesson": 21,
     "difficulty": "intermediate",
     "category": "comparison",
-    "example": "十八歳以上です。"
+    "example": "十八歳以上です。",
+    "kanji_search_results": [
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      },
+      {
+        "kanji": "以",
+        "mean": "DĨ"
+      }
+    ]
   },
   {
     "japanese": "までに",

--- a/data/lesson_22_vocabulary.json
+++ b/data/lesson_22_vocabulary.json
@@ -7,7 +7,17 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "toy",
-    "example": "人形を買いました。"
+    "example": "人形を買いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "ハンカチ",
@@ -27,7 +37,21 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "item",
-    "example": "蛍光灯を交換しました。"
+    "example": "蛍光灯を交換しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "蛍",
+        "mean": "HUỲNH"
+      },
+      {
+        "kanji": "光",
+        "mean": "QUANG"
+      },
+      {
+        "kanji": "灯",
+        "mean": "ĐĂNG"
+      }
+    ]
   },
   {
     "japanese": "けが",
@@ -57,7 +81,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "time",
-    "example": "良い日でした。"
+    "example": "良い日でした。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "とおく",
@@ -67,7 +97,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "place",
-    "example": "遠くから来ました。"
+    "example": "遠くから来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "遠",
+        "mean": "VIỄN, VIỂN"
+      }
+    ]
   },
   {
     "japanese": "インターンシップ",
@@ -87,7 +123,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "abstract",
-    "example": "旅行が楽しみです。"
+    "example": "旅行が楽しみです。",
+    "kanji_search_results": [
+      {
+        "kanji": "楽",
+        "mean": "LẠC, NHẠC"
+      }
+    ]
   },
   {
     "japanese": "みなさま",
@@ -97,7 +139,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "person",
-    "example": "皆様、ありがとうございます。"
+    "example": "皆様、ありがとうございます。",
+    "kanji_search_results": [
+      {
+        "kanji": "皆",
+        "mean": "GIAI"
+      },
+      {
+        "kanji": "様",
+        "mean": "DẠNG"
+      }
+    ]
   },
   {
     "japanese": "こと",
@@ -117,7 +169,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "abstract",
-    "example": "良い機会です。"
+    "example": "良い機会です。",
+    "kanji_search_results": [
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "こちら",
@@ -167,7 +229,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "子供を連れて行きました。"
+    "example": "子供を連れて行きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "連",
+        "mean": "LIÊN"
+      }
+    ]
   },
   {
     "japanese": "つれて くる",
@@ -177,7 +249,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "友達を連れて来ました。"
+    "example": "友達を連れて来ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "連",
+        "mean": "LIÊN"
+      },
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      }
+    ]
   },
   {
     "japanese": "みる",
@@ -187,7 +269,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "エアコンを見てもらいました。"
+    "example": "エアコンを見てもらいました。",
+    "kanji_search_results": [
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "なおす",
@@ -197,7 +285,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "時計を直しました。"
+    "example": "時計を直しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "直",
+        "mean": "TRỰC"
+      }
+    ]
   },
   {
     "japanese": "とりかえる",
@@ -207,7 +301,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "部品を取り替えました。"
+    "example": "部品を取り替えました。",
+    "kanji_search_results": [
+      {
+        "kanji": "替",
+        "mean": "THẾ"
+      },
+      {
+        "kanji": "取",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "ごうかくする",
@@ -217,7 +321,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "試験に合格しました。"
+    "example": "試験に合格しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "格",
+        "mean": "CÁCH, CÁC"
+      },
+      {
+        "kanji": "合",
+        "mean": "HỢP, CÁP, HIỆP"
+      }
+    ]
   },
   {
     "japanese": "わたす",
@@ -227,7 +341,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "書類を渡しました。"
+    "example": "書類を渡しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "渡",
+        "mean": "ĐỘ"
+      }
+    ]
   },
   {
     "japanese": "つける",
@@ -247,7 +367,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "プリントを配りました。"
+    "example": "プリントを配りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "配",
+        "mean": "PHỐI"
+      }
+    ]
   },
   {
     "japanese": "うれしい",
@@ -267,7 +393,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "time",
-    "example": "この間、会いました。"
+    "example": "この間、会いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      }
+    ]
   },
   {
     "japanese": "けん",
@@ -277,7 +409,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "神奈川県に住んでいます。"
+    "example": "神奈川県に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "県",
+        "mean": "HUYỆN"
+      }
+    ]
   },
   {
     "japanese": "と",
@@ -287,7 +425,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "東京都に住んでいます。"
+    "example": "東京都に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "都",
+        "mean": "ĐÔ"
+      }
+    ]
   },
   {
     "japanese": "し",
@@ -297,7 +441,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "横浜市に住んでいます。"
+    "example": "横浜市に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "市",
+        "mean": "THỊ"
+      }
+    ]
   },
   {
     "japanese": "く",
@@ -307,7 +457,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "文京区に住んでいます。"
+    "example": "文京区に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "区",
+        "mean": "KHU, ÂU"
+      }
+    ]
   },
   {
     "japanese": "さま",
@@ -317,7 +473,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "honorific",
-    "example": "田中様、お待ちしております。"
+    "example": "田中様、お待ちしております。",
+    "kanji_search_results": [
+      {
+        "kanji": "様",
+        "mean": "DẠNG"
+      }
+    ]
   },
   {
     "japanese": "ごめん",
@@ -337,7 +499,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "expression",
-    "example": "お世話になりました。ありがとうございました。"
+    "example": "お世話になりました。ありがとうございました。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "世",
+        "mean": "THẾ"
+      }
+    ]
   },
   {
     "japanese": "いいえ、こちらこそ",
@@ -357,7 +529,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "expression",
-    "example": "お元気で。また会いましょう。"
+    "example": "お元気で。また会いましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      },
+      {
+        "kanji": "元",
+        "mean": "NGUYÊN"
+      }
+    ]
   },
   {
     "japanese": "おげんきですか",
@@ -367,7 +549,17 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "お元気ですか。はい、元気です。"
+    "example": "お元気ですか。はい、元気です。",
+    "kanji_search_results": [
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      },
+      {
+        "kanji": "元",
+        "mean": "NGUYÊN"
+      }
+    ]
   },
   {
     "japanese": "そうでしたね",
@@ -397,7 +589,21 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "文京区に住んでいます。"
+    "example": "文京区に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "京",
+        "mean": "KINH"
+      },
+      {
+        "kanji": "区",
+        "mean": "KHU, ÂU"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "こいしかわ",
@@ -407,7 +613,21 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "小石川で会いましょう。"
+    "example": "小石川で会いましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "小",
+        "mean": "TIỂU"
+      },
+      {
+        "kanji": "石",
+        "mean": "THẠCH"
+      },
+      {
+        "kanji": "川",
+        "mean": "XUYÊN"
+      }
+    ]
   },
   {
     "japanese": "ながさき",
@@ -417,7 +637,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "長崎県に住んでいます。"
+    "example": "長崎県に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "崎",
+        "mean": "KHI"
+      },
+      {
+        "kanji": "長",
+        "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "うえだし",
@@ -427,7 +657,21 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "上田市に住んでいます。"
+    "example": "上田市に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "市",
+        "mean": "THỊ"
+      },
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
+      },
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "うえだ",
@@ -437,7 +681,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "place",
-    "example": "上田で会いましょう。"
+    "example": "上田で会いましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
+      },
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "ぼく",
@@ -447,7 +701,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "pronoun",
-    "example": "僕は学生です。"
+    "example": "僕は学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "僕",
+        "mean": "PHÓ, BỘC"
+      }
+    ]
   },
   {
     "japanese": "けしゴム",
@@ -457,7 +717,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "item",
-    "example": "消しゴムで消しました。"
+    "example": "消しゴムで消しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "消",
+        "mean": "TIÊU"
+      }
+    ]
   },
   {
     "japanese": "ドア",
@@ -477,7 +743,21 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "education",
-    "example": "小学校で勉強しました。"
+    "example": "小学校で勉強しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "小",
+        "mean": "TIỂU"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      }
+    ]
   },
   {
     "japanese": "みんな",
@@ -497,7 +777,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "abstract",
-    "example": "声がきれいです。"
+    "example": "声がきれいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "声",
+        "mean": "THANH"
+      }
+    ]
   },
   {
     "japanese": "ぶん",
@@ -507,7 +793,13 @@
     "lesson": 22,
     "difficulty": "beginner",
     "category": "education",
-    "example": "文を作りました。"
+    "example": "文を作りました。",
+    "kanji_search_results": [
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "おどろく",
@@ -517,7 +809,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "verb",
-    "example": "驚きました。"
+    "example": "驚きました。",
+    "kanji_search_results": [
+      {
+        "kanji": "驚",
+        "mean": "KINH"
+      }
+    ]
   },
   {
     "japanese": "さびしい",
@@ -527,7 +825,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "adjective",
-    "example": "寂しいです。"
+    "example": "寂しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "寂",
+        "mean": "TỊCH"
+      }
+    ]
   },
   {
     "japanese": "ある ～",
@@ -547,7 +851,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "grammar",
-    "example": "同じ色です。"
+    "example": "同じ色です。",
+    "kanji_search_results": [
+      {
+        "kanji": "同",
+        "mean": "ĐỒNG"
+      }
+    ]
   },
   {
     "japanese": "くん",
@@ -557,7 +867,13 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "honorific",
-    "example": "田中君、こんにちは。"
+    "example": "田中君、こんにちは。",
+    "kanji_search_results": [
+      {
+        "kanji": "君",
+        "mean": "QUÂN"
+      }
+    ]
   },
   {
     "japanese": "おめでとう",
@@ -577,7 +893,17 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "name",
-    "example": "石田さんに会いました。"
+    "example": "石田さんに会いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "石",
+        "mean": "THẠCH"
+      },
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
+      }
+    ]
   },
   {
     "japanese": "ゆうた",
@@ -587,6 +913,16 @@
     "lesson": 22,
     "difficulty": "intermediate",
     "category": "name",
-    "example": "勇太君、こんにちは。"
+    "example": "勇太君、こんにちは。",
+    "kanji_search_results": [
+      {
+        "kanji": "太",
+        "mean": "THÁI"
+      },
+      {
+        "kanji": "勇",
+        "mean": "DŨNG"
+      }
+    ]
   }
 ]

--- a/data/lesson_22_vocabulary.json
+++ b/data/lesson_22_vocabulary.json
@@ -10,12 +10,12 @@
     "example": "人形を買いました。",
     "kanji_search_results": [
       {
-        "kanji": "形",
-        "mean": "HÌNH"
-      },
-      {
         "kanji": "人",
         "mean": "NHÂN"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
       }
     ]
   },
@@ -232,12 +232,12 @@
     "example": "子供を連れて行きました。",
     "kanji_search_results": [
       {
-        "kanji": "行",
-        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
-      },
-      {
         "kanji": "連",
         "mean": "LIÊN"
+      },
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       }
     ]
   },
@@ -304,12 +304,12 @@
     "example": "部品を取り替えました。",
     "kanji_search_results": [
       {
-        "kanji": "替",
-        "mean": "THẾ"
-      },
-      {
         "kanji": "取",
         "mean": "THỦ"
+      },
+      {
+        "kanji": "替",
+        "mean": "THẾ"
       }
     ]
   },
@@ -324,12 +324,12 @@
     "example": "試験に合格しました。",
     "kanji_search_results": [
       {
-        "kanji": "格",
-        "mean": "CÁCH, CÁC"
-      },
-      {
         "kanji": "合",
         "mean": "HỢP, CÁP, HIỆP"
+      },
+      {
+        "kanji": "格",
+        "mean": "CÁCH, CÁC"
       }
     ]
   },
@@ -502,12 +502,12 @@
     "example": "お世話になりました。ありがとうございました。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
         "kanji": "世",
         "mean": "THẾ"
+      },
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
       }
     ]
   },
@@ -532,12 +532,12 @@
     "example": "お元気で。また会いましょう。",
     "kanji_search_results": [
       {
-        "kanji": "気",
-        "mean": "KHÍ"
-      },
-      {
         "kanji": "元",
         "mean": "NGUYÊN"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
       }
     ]
   },
@@ -552,12 +552,12 @@
     "example": "お元気ですか。はい、元気です。",
     "kanji_search_results": [
       {
-        "kanji": "気",
-        "mean": "KHÍ"
-      },
-      {
         "kanji": "元",
         "mean": "NGUYÊN"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
       }
     ]
   },
@@ -592,16 +592,16 @@
     "example": "文京区に住んでいます。",
     "kanji_search_results": [
       {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      },
+      {
         "kanji": "京",
         "mean": "KINH"
       },
       {
         "kanji": "区",
         "mean": "KHU, ÂU"
-      },
-      {
-        "kanji": "文",
-        "mean": "VĂN, VẤN"
       }
     ]
   },
@@ -640,12 +640,12 @@
     "example": "長崎県に住んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "崎",
-        "mean": "KHI"
-      },
-      {
         "kanji": "長",
         "mean": "TRƯỜNG, TRƯỞNG, TRƯỚNG"
+      },
+      {
+        "kanji": "崎",
+        "mean": "KHI"
       }
     ]
   },
@@ -660,16 +660,16 @@
     "example": "上田市に住んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "市",
-        "mean": "THỊ"
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
       },
       {
         "kanji": "田",
         "mean": "ĐIỀN"
       },
       {
-        "kanji": "上",
-        "mean": "THƯỢNG, THƯỚNG"
+        "kanji": "市",
+        "mean": "THỊ"
       }
     ]
   },
@@ -684,12 +684,12 @@
     "example": "上田で会いましょう。",
     "kanji_search_results": [
       {
-        "kanji": "田",
-        "mean": "ĐIỀN"
-      },
-      {
         "kanji": "上",
         "mean": "THƯỢNG, THƯỚNG"
+      },
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
       }
     ]
   },
@@ -916,12 +916,12 @@
     "example": "勇太君、こんにちは。",
     "kanji_search_results": [
       {
-        "kanji": "太",
-        "mean": "THÁI"
-      },
-      {
         "kanji": "勇",
         "mean": "DŨNG"
+      },
+      {
+        "kanji": "太",
+        "mean": "THÁI"
       }
     ]
   }

--- a/data/lesson_2_vocabulary.json
+++ b/data/lesson_2_vocabulary.json
@@ -172,12 +172,12 @@
     "example": "財布を忘れました。",
     "kanji_search_results": [
       {
-        "kanji": "布",
-        "mean": "BỐ"
-      },
-      {
         "kanji": "財",
         "mean": "TÀI"
+      },
+      {
+        "kanji": "布",
+        "mean": "BỐ"
       }
     ]
   },
@@ -192,12 +192,12 @@
     "example": "新聞を読みます。",
     "kanji_search_results": [
       {
-        "kanji": "聞",
-        "mean": "VĂN, VẤN, VẶN"
-      },
-      {
         "kanji": "新",
         "mean": "TÂN"
+      },
+      {
+        "kanji": "聞",
+        "mean": "VĂN, VẤN, VẶN"
       }
     ]
   },
@@ -212,12 +212,12 @@
     "example": "砂糖を入れます。",
     "kanji_search_results": [
       {
-        "kanji": "糖",
-        "mean": "ĐƯỜNG"
-      },
-      {
         "kanji": "砂",
         "mean": "SA"
+      },
+      {
+        "kanji": "糖",
+        "mean": "ĐƯỜNG"
       }
     ]
   },
@@ -314,12 +314,12 @@
     "example": "紅茶を飲みます。",
     "kanji_search_results": [
       {
-        "kanji": "茶",
-        "mean": "TRÀ"
-      },
-      {
         "kanji": "紅",
         "mean": "HỒNG"
+      },
+      {
+        "kanji": "茶",
+        "mean": "TRÀ"
       }
     ]
   },
@@ -374,20 +374,20 @@
     "example": "携帯電話で話します。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
-        "kanji": "電",
-        "mean": "ĐIỆN"
+        "kanji": "携",
+        "mean": "HUỀ"
       },
       {
         "kanji": "帯",
         "mean": "ĐỚI"
       },
       {
-        "kanji": "携",
-        "mean": "HUỀ"
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
       }
     ]
   },
@@ -512,12 +512,12 @@
     "example": "牛肉を焼きます。",
     "kanji_search_results": [
       {
-        "kanji": "肉",
-        "mean": "NHỤC, NHỤ, NẬU"
-      },
-      {
         "kanji": "牛",
         "mean": "NGƯU"
+      },
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
       }
     ]
   },
@@ -598,12 +598,12 @@
         "mean": "THIÊU"
       },
       {
-        "kanji": "定",
-        "mean": "ĐỊNH, ĐÍNH"
-      },
-      {
         "kanji": "肉",
         "mean": "NHỤC, NHỤ, NẬU"
+      },
+      {
+        "kanji": "定",
+        "mean": "ĐỊNH, ĐÍNH"
       },
       {
         "kanji": "食",

--- a/data/lesson_2_vocabulary.json
+++ b/data/lesson_2_vocabulary.json
@@ -77,7 +77,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "stationery",
-    "example": "本を読みます。"
+    "example": "本を読みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "本",
+        "mean": "BỔN, BẢN"
+      }
+    ]
   },
   {
     "japanese": "ざっし",
@@ -87,7 +93,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "stationery",
-    "example": "雑誌を買いました。"
+    "example": "雑誌を買いました。",
+    "kanji_search_results": [
+      {
+        "kanji": "雑",
+        "mean": "TẠP"
+      },
+      {
+        "kanji": "誌",
+        "mean": "CHÍ"
+      }
+    ]
   },
   {
     "japanese": "パソコン",
@@ -107,7 +123,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "object",
-    "example": "傘を持って行きます。"
+    "example": "傘を持って行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "傘",
+        "mean": "TÁN, TẢN"
+      }
+    ]
   },
   {
     "japanese": "かばん",
@@ -147,7 +169,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "object",
-    "example": "財布を忘れました。"
+    "example": "財布を忘れました。",
+    "kanji_search_results": [
+      {
+        "kanji": "布",
+        "mean": "BỐ"
+      },
+      {
+        "kanji": "財",
+        "mean": "TÀI"
+      }
+    ]
   },
   {
     "japanese": "しんぶん",
@@ -157,7 +189,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "stationery",
-    "example": "新聞を読みます。"
+    "example": "新聞を読みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "聞",
+        "mean": "VĂN, VẤN, VẶN"
+      },
+      {
+        "kanji": "新",
+        "mean": "TÂN"
+      }
+    ]
   },
   {
     "japanese": "さとう",
@@ -167,7 +209,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "砂糖を入れます。"
+    "example": "砂糖を入れます。",
+    "kanji_search_results": [
+      {
+        "kanji": "糖",
+        "mean": "ĐƯỜNG"
+      },
+      {
+        "kanji": "砂",
+        "mean": "SA"
+      }
+    ]
   },
   {
     "japanese": "しお",
@@ -177,7 +229,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "塩を少しかけます。"
+    "example": "塩を少しかけます。",
+    "kanji_search_results": [
+      {
+        "kanji": "塩",
+        "mean": "DIÊM"
+      }
+    ]
   },
   {
     "japanese": "しょうゆ",
@@ -227,7 +285,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "drink",
-    "example": "水を飲みます。"
+    "example": "水を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "水",
+        "mean": "THỦY"
+      }
+    ]
   },
   {
     "japanese": "ジュース",
@@ -247,7 +311,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "drink",
-    "example": "紅茶を飲みます。"
+    "example": "紅茶を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "茶",
+        "mean": "TRÀ"
+      },
+      {
+        "kanji": "紅",
+        "mean": "HỒNG"
+      }
+    ]
   },
   {
     "japanese": "コーヒー",
@@ -297,7 +371,25 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "electronics",
-    "example": "携帯電話で話します。"
+    "example": "携帯電話で話します。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "帯",
+        "mean": "ĐỚI"
+      },
+      {
+        "kanji": "携",
+        "mean": "HUỀ"
+      }
+    ]
   },
   {
     "japanese": "くるま",
@@ -307,7 +399,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "vehicle",
-    "example": "車で行きます。"
+    "example": "車で行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "車",
+        "mean": "XA"
+      }
+    ]
   },
   {
     "japanese": "～せい",
@@ -317,7 +415,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "日本製の時計です。"
+    "example": "日本製の時計です。",
+    "kanji_search_results": [
+      {
+        "kanji": "製",
+        "mean": "CHẾ"
+      }
+    ]
   },
   {
     "japanese": "ひと",
@@ -327,7 +431,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "person",
-    "example": "あの人は先生です。"
+    "example": "あの人は先生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "シャープペンシル",
@@ -347,7 +457,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "とり肉を食べます。"
+    "example": "とり肉を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
+      }
+    ]
   },
   {
     "japanese": "ぶたにく",
@@ -357,7 +473,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "豚肉を買います。"
+    "example": "豚肉を買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "豚",
+        "mean": "ĐỒN, ĐỘN"
+      },
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
+      }
+    ]
   },
   {
     "japanese": "ぎゅうどん",
@@ -367,7 +493,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "牛どんを食べます。"
+    "example": "牛どんを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "牛",
+        "mean": "NGƯU"
+      }
+    ]
   },
   {
     "japanese": "ぎゅうにく",
@@ -377,7 +509,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "牛肉を焼きます。"
+    "example": "牛肉を焼きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
+      },
+      {
+        "kanji": "牛",
+        "mean": "NGƯU"
+      }
+    ]
   },
   {
     "japanese": "にく",
@@ -387,7 +529,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "肉を食べます。"
+    "example": "肉を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
+      }
+    ]
   },
   {
     "japanese": "おやこどん",
@@ -397,7 +545,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "親子どんを注文します。"
+    "example": "親子どんを注文します。",
+    "kanji_search_results": [
+      {
+        "kanji": "親",
+        "mean": "THÂN, THẤN"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "すきやき",
@@ -407,7 +565,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "すき焼きを食べます。"
+    "example": "すき焼きを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "焼",
+        "mean": "THIÊU"
+      }
+    ]
   },
   {
     "japanese": "ラーメン",
@@ -427,7 +591,25 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "food",
-    "example": "焼肉定食を注文します。"
+    "example": "焼肉定食を注文します。",
+    "kanji_search_results": [
+      {
+        "kanji": "焼",
+        "mean": "THIÊU"
+      },
+      {
+        "kanji": "定",
+        "mean": "ĐỊNH, ĐÍNH"
+      },
+      {
+        "kanji": "肉",
+        "mean": "NHỤC, NHỤ, NẬU"
+      },
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      }
+    ]
   },
   {
     "japanese": "ＣＤ",
@@ -447,7 +629,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "日本語を勉強します。"
+    "example": "日本語を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "語",
+        "mean": "NGỮ, NGỨ"
+      }
+    ]
   },
   {
     "japanese": "なん",
@@ -457,7 +645,13 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何ですか。"
+    "example": "何ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      }
+    ]
   },
   {
     "japanese": "だれ",
@@ -507,7 +701,17 @@
     "lesson": 2,
     "difficulty": "beginner",
     "category": "name",
-    "example": "渡辺あきさんです。"
+    "example": "渡辺あきさんです。",
+    "kanji_search_results": [
+      {
+        "kanji": "渡",
+        "mean": "ĐỘ"
+      },
+      {
+        "kanji": "辺",
+        "mean": "BIÊN"
+      }
+    ]
   },
   {
     "japanese": "トム・ジョーダン",

--- a/data/lesson_3_vocabulary.json
+++ b/data/lesson_3_vocabulary.json
@@ -40,12 +40,12 @@
     "example": "食堂で昼ご飯を食べます。",
     "kanji_search_results": [
       {
-        "kanji": "堂",
-        "mean": "ĐƯỜNG"
-      },
-      {
         "kanji": "食",
         "mean": "THỰC, TỰ"
+      },
+      {
+        "kanji": "堂",
+        "mean": "ĐƯỜNG"
       }
     ]
   },
@@ -96,16 +96,16 @@
     "example": "事務室で働いています。",
     "kanji_search_results": [
       {
-        "kanji": "室",
-        "mean": "THẤT"
+        "kanji": "事",
+        "mean": "SỰ"
       },
       {
         "kanji": "務",
         "mean": "VỤ, VŨ"
       },
       {
-        "kanji": "事",
-        "mean": "SỰ"
+        "kanji": "室",
+        "mean": "THẤT"
       }
     ]
   },
@@ -120,16 +120,16 @@
     "example": "会議室で会議をします。",
     "kanji_search_results": [
       {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
         "kanji": "議",
         "mean": "NGHỊ"
       },
       {
         "kanji": "室",
         "mean": "THẤT"
-      },
-      {
-        "kanji": "会",
-        "mean": "HỘI, CỐI"
       }
     ]
   },
@@ -174,12 +174,12 @@
         "mean": "ĐỒ"
       },
       {
-        "kanji": "室",
-        "mean": "THẤT"
-      },
-      {
         "kanji": "書",
         "mean": "THƯ"
+      },
+      {
+        "kanji": "室",
+        "mean": "THẤT"
       }
     ]
   },
@@ -194,12 +194,12 @@
     "example": "教室で授業をします。",
     "kanji_search_results": [
       {
-        "kanji": "室",
-        "mean": "THẤT"
-      },
-      {
         "kanji": "教",
         "mean": "GIÁO, GIAO"
+      },
+      {
+        "kanji": "室",
+        "mean": "THẤT"
       }
     ]
   },
@@ -240,16 +240,16 @@
     "example": "郵便局で手紙を送ります。",
     "kanji_search_results": [
       {
-        "kanji": "局",
-        "mean": "CỤC"
+        "kanji": "郵",
+        "mean": "BƯU"
       },
       {
         "kanji": "便",
         "mean": "TIỆN"
       },
       {
-        "kanji": "郵",
-        "mean": "BƯU"
+        "kanji": "局",
+        "mean": "CỤC"
       }
     ]
   },
@@ -264,12 +264,12 @@
     "example": "病院に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "院",
-        "mean": "VIỆN"
-      },
-      {
         "kanji": "病",
         "mean": "BỆNH"
+      },
+      {
+        "kanji": "院",
+        "mean": "VIỆN"
       }
     ]
   },
@@ -284,12 +284,12 @@
     "example": "大使館で手続きをします。",
     "kanji_search_results": [
       {
-        "kanji": "使",
-        "mean": "SỬ, SỨ"
-      },
-      {
         "kanji": "大",
         "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "使",
+        "mean": "SỬ, SỨ"
       },
       {
         "kanji": "館",
@@ -308,12 +308,12 @@
     "example": "銀行でお金を下ろします。",
     "kanji_search_results": [
       {
-        "kanji": "行",
-        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
-      },
-      {
         "kanji": "銀",
         "mean": "NGÂN"
+      },
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       }
     ]
   },
@@ -364,12 +364,12 @@
     "example": "辞書で単語を調べます。",
     "kanji_search_results": [
       {
-        "kanji": "書",
-        "mean": "THƯ"
-      },
-      {
         "kanji": "辞",
         "mean": "TỪ"
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
       }
     ]
   },
@@ -384,12 +384,12 @@
     "example": "地図を見て道を探します。",
     "kanji_search_results": [
       {
-        "kanji": "図",
-        "mean": "ĐỒ"
-      },
-      {
         "kanji": "地",
         "mean": "ĐỊA"
+      },
+      {
+        "kanji": "図",
+        "mean": "ĐỒ"
       }
     ]
   },
@@ -404,16 +404,16 @@
     "example": "冷蔵庫に食べ物を入れます。",
     "kanji_search_results": [
       {
-        "kanji": "庫",
-        "mean": "KHỐ"
+        "kanji": "冷",
+        "mean": "LÃNH"
       },
       {
         "kanji": "蔵",
         "mean": "TÀNG"
       },
       {
-        "kanji": "冷",
-        "mean": "LÃNH"
+        "kanji": "庫",
+        "mean": "KHỐ"
       }
     ]
   },
@@ -438,12 +438,12 @@
     "example": "時計を見て時間を確認します。",
     "kanji_search_results": [
       {
-        "kanji": "計",
-        "mean": "KẾ, KÊ"
-      },
-      {
         "kanji": "時",
         "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "計",
+        "mean": "KẾ, KÊ"
       }
     ]
   },
@@ -478,12 +478,12 @@
     "example": "洗濯機で服を洗います。",
     "kanji_search_results": [
       {
-        "kanji": "濯",
-        "mean": "TRẠC"
-      },
-      {
         "kanji": "洗",
         "mean": "TẨY, TIỂN"
+      },
+      {
+        "kanji": "濯",
+        "mean": "TRẠC"
       },
       {
         "kanji": "機",
@@ -502,16 +502,16 @@
     "example": "掃除機で掃除します。",
     "kanji_search_results": [
       {
+        "kanji": "掃",
+        "mean": "TẢO"
+      },
+      {
         "kanji": "除",
         "mean": "TRỪ"
       },
       {
         "kanji": "機",
         "mean": "KI, CƠ"
-      },
-      {
-        "kanji": "掃",
-        "mean": "TẢO"
       }
     ]
   },
@@ -840,12 +840,12 @@
     "example": "ゆり大学で勉強しています。",
     "kanji_search_results": [
       {
-        "kanji": "学",
-        "mean": "HỌC"
-      },
-      {
         "kanji": "大",
         "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "学",
+        "mean": "HỌC"
       }
     ]
   }

--- a/data/lesson_3_vocabulary.json
+++ b/data/lesson_3_vocabulary.json
@@ -37,7 +37,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "食堂で昼ご飯を食べます。"
+    "example": "食堂で昼ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "堂",
+        "mean": "ĐƯỜNG"
+      },
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      }
+    ]
   },
   {
     "japanese": "うけつけ",
@@ -47,7 +57,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "受付で手続きをします。"
+    "example": "受付で手続きをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "受",
+        "mean": "THỤ"
+      },
+      {
+        "kanji": "付",
+        "mean": "PHÓ"
+      }
+    ]
   },
   {
     "japanese": "～しつ",
@@ -57,7 +77,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "事務室にいます。"
+    "example": "事務室にいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      }
+    ]
   },
   {
     "japanese": "じむしつ",
@@ -67,7 +93,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "事務室で働いています。"
+    "example": "事務室で働いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "務",
+        "mean": "VỤ, VŨ"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "かいぎしつ",
@@ -77,7 +117,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "会議室で会議をします。"
+    "example": "会議室で会議をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "議",
+        "mean": "NGHỊ"
+      },
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "コンピューターしつ",
@@ -87,7 +141,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "コンピューター室で勉強します。"
+    "example": "コンピューター室で勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      }
+    ]
   },
   {
     "japanese": "トイレ",
@@ -107,7 +167,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "図書室で本を読みます。"
+    "example": "図書室で本を読みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "図",
+        "mean": "ĐỒ"
+      },
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      }
+    ]
   },
   {
     "japanese": "きょうしつ",
@@ -117,7 +191,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "教室で授業をします。"
+    "example": "教室で授業をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "室",
+        "mean": "THẤT"
+      },
+      {
+        "kanji": "教",
+        "mean": "GIÁO, GIAO"
+      }
+    ]
   },
   {
     "japanese": "ロビー",
@@ -137,7 +221,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "object",
-    "example": "コピー機でコピーします。"
+    "example": "コピー機でコピーします。",
+    "kanji_search_results": [
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      }
+    ]
   },
   {
     "japanese": "ゆうびんきょく",
@@ -147,7 +237,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "郵便局で手紙を送ります。"
+    "example": "郵便局で手紙を送ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "局",
+        "mean": "CỤC"
+      },
+      {
+        "kanji": "便",
+        "mean": "TIỆN"
+      },
+      {
+        "kanji": "郵",
+        "mean": "BƯU"
+      }
+    ]
   },
   {
     "japanese": "びょういん",
@@ -157,7 +261,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "病院に行きます。"
+    "example": "病院に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "院",
+        "mean": "VIỆN"
+      },
+      {
+        "kanji": "病",
+        "mean": "BỆNH"
+      }
+    ]
   },
   {
     "japanese": "たいしかん",
@@ -167,7 +281,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "大使館で手続きをします。"
+    "example": "大使館で手続きをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "使",
+        "mean": "SỬ, SỨ"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "館",
+        "mean": "QUÁN"
+      }
+    ]
   },
   {
     "japanese": "ぎんこう",
@@ -177,7 +305,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "銀行でお金を下ろします。"
+    "example": "銀行でお金を下ろします。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "銀",
+        "mean": "NGÂN"
+      }
+    ]
   },
   {
     "japanese": "コンビニ",
@@ -207,7 +345,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "駅で電車に乗ります。"
+    "example": "駅で電車に乗ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "駅",
+        "mean": "DỊCH"
+      }
+    ]
   },
   {
     "japanese": "じしょ",
@@ -217,7 +361,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "object",
-    "example": "辞書で単語を調べます。"
+    "example": "辞書で単語を調べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "辞",
+        "mean": "TỪ"
+      }
+    ]
   },
   {
     "japanese": "ちず",
@@ -227,7 +381,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "object",
-    "example": "地図を見て道を探します。"
+    "example": "地図を見て道を探します。",
+    "kanji_search_results": [
+      {
+        "kanji": "図",
+        "mean": "ĐỒ"
+      },
+      {
+        "kanji": "地",
+        "mean": "ĐỊA"
+      }
+    ]
   },
   {
     "japanese": "れいぞうこ",
@@ -237,7 +401,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "appliance",
-    "example": "冷蔵庫に食べ物を入れます。"
+    "example": "冷蔵庫に食べ物を入れます。",
+    "kanji_search_results": [
+      {
+        "kanji": "庫",
+        "mean": "KHỐ"
+      },
+      {
+        "kanji": "蔵",
+        "mean": "TÀNG"
+      },
+      {
+        "kanji": "冷",
+        "mean": "LÃNH"
+      }
+    ]
   },
   {
     "japanese": "エアコン",
@@ -257,7 +435,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "object",
-    "example": "時計を見て時間を確認します。"
+    "example": "時計を見て時間を確認します。",
+    "kanji_search_results": [
+      {
+        "kanji": "計",
+        "mean": "KẾ, KÊ"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "でんしレンジ",
@@ -267,7 +455,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "appliance",
-    "example": "電子レンジで温めます。"
+    "example": "電子レンジで温めます。",
+    "kanji_search_results": [
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "せんたくき",
@@ -277,7 +475,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "appliance",
-    "example": "洗濯機で服を洗います。"
+    "example": "洗濯機で服を洗います。",
+    "kanji_search_results": [
+      {
+        "kanji": "濯",
+        "mean": "TRẠC"
+      },
+      {
+        "kanji": "洗",
+        "mean": "TẨY, TIỂN"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      }
+    ]
   },
   {
     "japanese": "そうじき",
@@ -287,7 +499,21 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "appliance",
-    "example": "掃除機で掃除します。"
+    "example": "掃除機で掃除します。",
+    "kanji_search_results": [
+      {
+        "kanji": "除",
+        "mean": "TRỪ"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "掃",
+        "mean": "TẢO"
+      }
+    ]
   },
   {
     "japanese": "ポット",
@@ -307,7 +533,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "drink",
-    "example": "お茶を飲みます。"
+    "example": "お茶を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "茶",
+        "mean": "TRÀ"
+      }
+    ]
   },
   {
     "japanese": "ワイン",
@@ -347,7 +579,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "object",
-    "example": "靴を履きます。"
+    "example": "靴を履きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "靴",
+        "mean": "NGOA"
+      }
+    ]
   },
   {
     "japanese": "ひゃく",
@@ -357,7 +595,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "number",
-    "example": "百円です。"
+    "example": "百円です。",
+    "kanji_search_results": [
+      {
+        "kanji": "百",
+        "mean": "BÁCH, BÁ, MẠCH"
+      }
+    ]
   },
   {
     "japanese": "せん",
@@ -367,7 +611,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "number",
-    "example": "千円です。"
+    "example": "千円です。",
+    "kanji_search_results": [
+      {
+        "kanji": "千",
+        "mean": "THIÊN"
+      }
+    ]
   },
   {
     "japanese": "まん",
@@ -377,7 +627,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "number",
-    "example": "一万円です。"
+    "example": "一万円です。",
+    "kanji_search_results": [
+      {
+        "kanji": "万",
+        "mean": "VẠN, MẶC"
+      }
+    ]
   },
   {
     "japanese": "－かい",
@@ -387,7 +643,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "number",
-    "example": "三階にあります。"
+    "example": "三階にあります。",
+    "kanji_search_results": [
+      {
+        "kanji": "階",
+        "mean": "GIAI"
+      }
+    ]
   },
   {
     "japanese": "なん～",
@@ -397,7 +659,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何階ですか。"
+    "example": "何階ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      }
+    ]
   },
   {
     "japanese": "なんがい",
@@ -407,7 +675,17 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何階にありますか。"
+    "example": "何階にありますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "階",
+        "mean": "GIAI"
+      }
+    ]
   },
   {
     "japanese": "－えん",
@@ -417,7 +695,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "currency",
-    "example": "百円です。"
+    "example": "百円です。",
+    "kanji_search_results": [
+      {
+        "kanji": "円",
+        "mean": "VIÊN"
+      }
+    ]
   },
   {
     "japanese": "どこ",
@@ -457,7 +741,13 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "response",
-    "example": "違います。"
+    "example": "違います。",
+    "kanji_search_results": [
+      {
+        "kanji": "違",
+        "mean": "VI"
+      }
+    ]
   },
   {
     "japanese": "どうも",
@@ -547,6 +837,16 @@
     "lesson": 3,
     "difficulty": "beginner",
     "category": "place",
-    "example": "ゆり大学で勉強しています。"
+    "example": "ゆり大学で勉強しています。",
+    "kanji_search_results": [
+      {
+        "kanji": "学",
+        "mean": "HỌC"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   }
 ]

--- a/data/lesson_4_vocabulary.json
+++ b/data/lesson_4_vocabulary.json
@@ -86,12 +86,12 @@
     "example": "牛乳を飲みます。",
     "kanji_search_results": [
       {
-        "kanji": "乳",
-        "mean": "NHŨ"
-      },
-      {
         "kanji": "牛",
         "mean": "NGƯU"
+      },
+      {
+        "kanji": "乳",
+        "mean": "NHŨ"
       }
     ]
   },
@@ -138,12 +138,12 @@
     "example": "映画を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "画",
-        "mean": "HỌA, HOẠCH"
-      },
-      {
         "kanji": "映",
         "mean": "ÁNH"
+      },
+      {
+        "kanji": "画",
+        "mean": "HỌA, HOẠCH"
       }
     ]
   },
@@ -228,12 +228,12 @@
     "example": "宿題をします。",
     "kanji_search_results": [
       {
-        "kanji": "題",
-        "mean": "ĐỀ"
-      },
-      {
         "kanji": "宿",
         "mean": "TÚC, TÚ"
+      },
+      {
+        "kanji": "題",
+        "mean": "ĐỀ"
       }
     ]
   },
@@ -278,12 +278,12 @@
     "example": "手紙を書きます。",
     "kanji_search_results": [
       {
-        "kanji": "紙",
-        "mean": "CHỈ"
-      },
-      {
         "kanji": "手",
         "mean": "THỦ"
+      },
+      {
+        "kanji": "紙",
+        "mean": "CHỈ"
       }
     ]
   },
@@ -480,12 +480,12 @@
     "example": "晩ご飯を食べます。",
     "kanji_search_results": [
       {
-        "kanji": "飯",
-        "mean": "PHẠN, PHÃN"
-      },
-      {
         "kanji": "晩",
         "mean": "VÃN"
+      },
+      {
+        "kanji": "飯",
+        "mean": "PHẠN, PHÃN"
       }
     ]
   },
@@ -516,12 +516,12 @@
     "example": "お弁当を食べます。",
     "kanji_search_results": [
       {
-        "kanji": "当",
-        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
-      },
-      {
         "kanji": "弁",
         "mean": "BIỆN, BIỀN, BÀN"
+      },
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
       }
     ]
   },
@@ -536,12 +536,12 @@
     "example": "料理を作ります。",
     "kanji_search_results": [
       {
-        "kanji": "理",
-        "mean": "LÍ"
-      },
-      {
         "kanji": "料",
         "mean": "LIÊU, LIỆU"
+      },
+      {
+        "kanji": "理",
+        "mean": "LÍ"
       }
     ]
   },
@@ -616,12 +616,12 @@
     "example": "毎朝ジョギングをします。",
     "kanji_search_results": [
       {
-        "kanji": "朝",
-        "mean": "TRIÊU, TRIỀU"
-      },
-      {
         "kanji": "毎",
         "mean": "MỖI"
+      },
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
       }
     ]
   },
@@ -636,12 +636,12 @@
     "example": "毎晩テレビを見ます。",
     "kanji_search_results": [
       {
-        "kanji": "晩",
-        "mean": "VÃN"
-      },
-      {
         "kanji": "毎",
         "mean": "MỖI"
+      },
+      {
+        "kanji": "晩",
+        "mean": "VÃN"
       }
     ]
   },

--- a/data/lesson_4_vocabulary.json
+++ b/data/lesson_4_vocabulary.json
@@ -17,7 +17,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "魚を食べます。"
+    "example": "魚を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "魚",
+        "mean": "NGƯ"
+      }
+    ]
   },
   {
     "japanese": "くだもの",
@@ -27,7 +33,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "果物を買います。"
+    "example": "果物を買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "果",
+        "mean": "QUẢ"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "やさい",
@@ -37,7 +53,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "野菜を食べます。"
+    "example": "野菜を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "野",
+        "mean": "DÃ"
+      },
+      {
+        "kanji": "菜",
+        "mean": "THÁI"
+      }
+    ]
   },
   {
     "japanese": "カレー",
@@ -57,7 +83,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "drink",
-    "example": "牛乳を飲みます。"
+    "example": "牛乳を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "乳",
+        "mean": "NHŨ"
+      },
+      {
+        "kanji": "牛",
+        "mean": "NGƯU"
+      }
+    ]
   },
   {
     "japanese": "さけ",
@@ -67,7 +103,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "drink",
-    "example": "お酒を飲みます。"
+    "example": "お酒を飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "酒",
+        "mean": "TỬU"
+      }
+    ]
   },
   {
     "japanese": "たまご",
@@ -77,7 +119,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "卵を食べます。"
+    "example": "卵を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "卵",
+        "mean": "NOÃN"
+      }
+    ]
   },
   {
     "japanese": "えいが",
@@ -87,7 +135,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "映画を見ます。"
+    "example": "映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "画",
+        "mean": "HỌA, HOẠCH"
+      },
+      {
+        "kanji": "映",
+        "mean": "ÁNH"
+      }
+    ]
   },
   {
     "japanese": "おんがく",
@@ -97,7 +155,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "音楽を聞きます。"
+    "example": "音楽を聞きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "音",
+        "mean": "ÂM"
+      },
+      {
+        "kanji": "楽",
+        "mean": "LẠC, NHẠC"
+      }
+    ]
   },
   {
     "japanese": "クラシック",
@@ -157,7 +225,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "education",
-    "example": "宿題をします。"
+    "example": "宿題をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "題",
+        "mean": "ĐỀ"
+      },
+      {
+        "kanji": "宿",
+        "mean": "TÚC, TÚ"
+      }
+    ]
   },
   {
     "japanese": "ジョギング",
@@ -197,7 +275,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "object",
-    "example": "手紙を書きます。"
+    "example": "手紙を書きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "紙",
+        "mean": "CHỈ"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "おかね",
@@ -207,7 +295,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "object",
-    "example": "お金を払います。"
+    "example": "お金を払います。",
+    "kanji_search_results": [
+      {
+        "kanji": "金",
+        "mean": "KIM"
+      }
+    ]
   },
   {
     "japanese": "きって",
@@ -217,7 +311,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "object",
-    "example": "切手を買います。"
+    "example": "切手を買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "としょかん",
@@ -227,7 +331,21 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "place",
-    "example": "図書館で勉強します。"
+    "example": "図書館で勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "図",
+        "mean": "ĐỒ"
+      },
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      },
+      {
+        "kanji": "館",
+        "mean": "QUÁN"
+      }
+    ]
   },
   {
     "japanese": "こうえん",
@@ -237,7 +355,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "place",
-    "example": "公園を散歩します。"
+    "example": "公園を散歩します。",
+    "kanji_search_results": [
+      {
+        "kanji": "公",
+        "mean": "CÔNG"
+      },
+      {
+        "kanji": "園",
+        "mean": "VIÊN"
+      }
+    ]
   },
   {
     "japanese": "うち",
@@ -277,7 +405,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "パン屋です。"
+    "example": "パン屋です。",
+    "kanji_search_results": [
+      {
+        "kanji": "屋",
+        "mean": "ỐC"
+      }
+    ]
   },
   {
     "japanese": "パンや",
@@ -287,7 +421,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "place",
-    "example": "パン屋でパンを買います。"
+    "example": "パン屋でパンを買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "屋",
+        "mean": "ỐC"
+      }
+    ]
   },
   {
     "japanese": "ひるごはん",
@@ -297,7 +437,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "meal",
-    "example": "昼ご飯を食べます。"
+    "example": "昼ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "昼",
+        "mean": "TRÚ"
+      },
+      {
+        "kanji": "飯",
+        "mean": "PHẠN, PHÃN"
+      }
+    ]
   },
   {
     "japanese": "あさごはん",
@@ -307,7 +457,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "meal",
-    "example": "朝ご飯を食べます。"
+    "example": "朝ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
+      },
+      {
+        "kanji": "飯",
+        "mean": "PHẠN, PHÃN"
+      }
+    ]
   },
   {
     "japanese": "ばんごはん",
@@ -317,7 +477,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "meal",
-    "example": "晩ご飯を食べます。"
+    "example": "晩ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "飯",
+        "mean": "PHẠN, PHÃN"
+      },
+      {
+        "kanji": "晩",
+        "mean": "VÃN"
+      }
+    ]
   },
   {
     "japanese": "ごはん",
@@ -327,7 +497,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "meal",
-    "example": "ご飯を食べます。"
+    "example": "ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "飯",
+        "mean": "PHẠN, PHÃN"
+      }
+    ]
   },
   {
     "japanese": "べんとう",
@@ -337,7 +513,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "お弁当を食べます。"
+    "example": "お弁当を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "当",
+        "mean": "ĐƯƠNG, ĐANG, ĐÁNG"
+      },
+      {
+        "kanji": "弁",
+        "mean": "BIỆN, BIỀN, BÀN"
+      }
+    ]
   },
   {
     "japanese": "りょうり",
@@ -347,7 +533,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "food",
-    "example": "料理を作ります。"
+    "example": "料理を作ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "理",
+        "mean": "LÍ"
+      },
+      {
+        "kanji": "料",
+        "mean": "LIÊU, LIỆU"
+      }
+    ]
   },
   {
     "japanese": "こんばん",
@@ -357,7 +553,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今晩映画を見ます。"
+    "example": "今晩映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "晩",
+        "mean": "VÃN"
+      }
+    ]
   },
   {
     "japanese": "あした",
@@ -377,7 +583,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今日は忙しいです。"
+    "example": "今日は忙しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "あさって",
@@ -397,7 +613,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎朝ジョギングをします。"
+    "example": "毎朝ジョギングをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
+      },
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      }
+    ]
   },
   {
     "japanese": "まいばん",
@@ -407,7 +633,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎晩テレビを見ます。"
+    "example": "毎晩テレビを見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "晩",
+        "mean": "VÃN"
+      },
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      }
+    ]
   },
   {
     "japanese": "まいにち",
@@ -417,7 +653,17 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎日勉強します。"
+    "example": "毎日勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "たべます",
@@ -427,7 +673,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ご飯を食べます。"
+    "example": "ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      }
+    ]
   },
   {
     "japanese": "のみます",
@@ -437,7 +689,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "コーヒーを飲みます。"
+    "example": "コーヒーを飲みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "飲",
+        "mean": "ẨM, ẤM"
+      }
+    ]
   },
   {
     "japanese": "かいます",
@@ -447,7 +705,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を買います。"
+    "example": "本を買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "買",
+        "mean": "MÃI"
+      }
+    ]
   },
   {
     "japanese": "かきます",
@@ -457,7 +721,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "手紙を書きます。"
+    "example": "手紙を書きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "書",
+        "mean": "THƯ"
+      }
+    ]
   },
   {
     "japanese": "ききます",
@@ -467,7 +737,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "音楽を聞きます。"
+    "example": "音楽を聞きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "聞",
+        "mean": "VĂN, VẤN, VẶN"
+      }
+    ]
   },
   {
     "japanese": "みます",
@@ -477,7 +753,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "映画を見ます。"
+    "example": "映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "よみます",
@@ -487,7 +769,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "本を読みます。"
+    "example": "本を読みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "読",
+        "mean": "ĐỘC"
+      }
+    ]
   },
   {
     "japanese": "します",
@@ -507,7 +795,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お金を下ろします。"
+    "example": "お金を下ろします。",
+    "kanji_search_results": [
+      {
+        "kanji": "下",
+        "mean": "HẠ, HÁ"
+      }
+    ]
   },
   {
     "japanese": "なに",
@@ -517,7 +811,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何をしますか。"
+    "example": "何をしますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      }
+    ]
   },
   {
     "japanese": "いつも",
@@ -537,7 +837,13 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "時々映画を見ます。"
+    "example": "時々映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "それから",
@@ -557,6 +863,16 @@
     "lesson": 4,
     "difficulty": "beginner",
     "category": "education",
-    "example": "質問があります。"
+    "example": "質問があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "質",
+        "mean": "CHẤT, CHÍ"
+      },
+      {
+        "kanji": "問",
+        "mean": "VẤN"
+      }
+    ]
   }
 ]

--- a/data/lesson_5_vocabulary.json
+++ b/data/lesson_5_vocabulary.json
@@ -114,12 +114,12 @@
     "example": "三時半です。",
     "kanji_search_results": [
       {
-        "kanji": "半",
-        "mean": "BÁN"
-      },
-      {
         "kanji": "時",
         "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "半",
+        "mean": "BÁN"
       }
     ]
   },
@@ -274,12 +274,12 @@
     "example": "文法を勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "法",
-        "mean": "PHÁP"
-      },
-      {
         "kanji": "文",
         "mean": "VĂN, VẤN"
+      },
+      {
+        "kanji": "法",
+        "mean": "PHÁP"
       }
     ]
   },
@@ -294,12 +294,12 @@
     "example": "会話を練習します。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
         "kanji": "会",
         "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
       }
     ]
   },
@@ -314,12 +314,12 @@
     "example": "漢字を覚えます。",
     "kanji_search_results": [
       {
-        "kanji": "字",
-        "mean": "TỰ"
-      },
-      {
         "kanji": "漢",
         "mean": "HÁN"
+      },
+      {
+        "kanji": "字",
+        "mean": "TỰ"
       }
     ]
   },
@@ -364,12 +364,12 @@
     "example": "お風呂に入ります。",
     "kanji_search_results": [
       {
-        "kanji": "呂",
-        "mean": "LỮ, LÃ"
-      },
-      {
         "kanji": "風",
         "mean": "PHONG"
+      },
+      {
+        "kanji": "呂",
+        "mean": "LỮ, LÃ"
       }
     ]
   },
@@ -384,12 +384,12 @@
     "example": "お相撲さんを見ます。",
     "kanji_search_results": [
       {
-        "kanji": "撲",
-        "mean": "PHÁC, BẠC, PHỐC"
-      },
-      {
         "kanji": "相",
         "mean": "TƯƠNG, TƯỚNG"
+      },
+      {
+        "kanji": "撲",
+        "mean": "PHÁC, BẠC, PHỐC"
       }
     ]
   },
@@ -420,12 +420,12 @@
     "example": "先週映画を見ました。",
     "kanji_search_results": [
       {
-        "kanji": "週",
-        "mean": "CHU"
-      },
-      {
         "kanji": "先",
         "mean": "TIÊN, TIẾN"
+      },
+      {
+        "kanji": "週",
+        "mean": "CHU"
       }
     ]
   },
@@ -460,12 +460,12 @@
     "example": "来週休みです。",
     "kanji_search_results": [
       {
-        "kanji": "週",
-        "mean": "CHU"
-      },
-      {
         "kanji": "来",
         "mean": "LAI, LÃI"
+      },
+      {
+        "kanji": "週",
+        "mean": "CHU"
       }
     ]
   },
@@ -480,12 +480,12 @@
     "example": "毎週映画を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "週",
-        "mean": "CHU"
-      },
-      {
         "kanji": "毎",
         "mean": "MỖI"
+      },
+      {
+        "kanji": "週",
+        "mean": "CHU"
       }
     ]
   },
@@ -500,16 +500,16 @@
     "example": "月曜日に学校に行きます。",
     "kanji_search_results": [
       {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      },
+      {
         "kanji": "曜",
         "mean": "DIỆU"
       },
       {
         "kanji": "日",
         "mean": "NHẬT, NHỰT"
-      },
-      {
-        "kanji": "月",
-        "mean": "NGUYỆT"
       }
     ]
   },
@@ -524,12 +524,12 @@
     "example": "火曜日に会議があります。",
     "kanji_search_results": [
       {
-        "kanji": "曜",
-        "mean": "DIỆU"
-      },
-      {
         "kanji": "火",
         "mean": "HỎA"
+      },
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
       },
       {
         "kanji": "日",
@@ -548,16 +548,16 @@
     "example": "水曜日に買い物をします。",
     "kanji_search_results": [
       {
+        "kanji": "水",
+        "mean": "THỦY"
+      },
+      {
         "kanji": "曜",
         "mean": "DIỆU"
       },
       {
         "kanji": "日",
         "mean": "NHẬT, NHỰT"
-      },
-      {
-        "kanji": "水",
-        "mean": "THỦY"
       }
     ]
   },
@@ -572,12 +572,12 @@
     "example": "木曜日に映画を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "曜",
-        "mean": "DIỆU"
-      },
-      {
         "kanji": "木",
         "mean": "MỘC"
+      },
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
       },
       {
         "kanji": "日",
@@ -596,12 +596,12 @@
     "example": "金曜日にパーティーをします。",
     "kanji_search_results": [
       {
-        "kanji": "曜",
-        "mean": "DIỆU"
-      },
-      {
         "kanji": "金",
         "mean": "KIM"
+      },
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
       },
       {
         "kanji": "日",
@@ -620,16 +620,16 @@
     "example": "土曜日に休みます。",
     "kanji_search_results": [
       {
+        "kanji": "土",
+        "mean": "THỔ, ĐỘ, ĐỖ"
+      },
+      {
         "kanji": "曜",
         "mean": "DIỆU"
       },
       {
         "kanji": "日",
         "mean": "NHẬT, NHỰT"
-      },
-      {
-        "kanji": "土",
-        "mean": "THỔ, ĐỘ, ĐỖ"
       }
     ]
   },
@@ -644,12 +644,12 @@
     "example": "日曜日に家族と過ごします。",
     "kanji_search_results": [
       {
-        "kanji": "曜",
-        "mean": "DIỆU"
-      },
-      {
         "kanji": "日",
         "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
       }
     ]
   },
@@ -734,12 +734,12 @@
     "example": "今朝コーヒーを飲みました。",
     "kanji_search_results": [
       {
-        "kanji": "朝",
-        "mean": "TRIÊU, TRIỀU"
-      },
-      {
         "kanji": "今",
         "mean": "KIM"
+      },
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
       }
     ]
   },
@@ -938,12 +938,12 @@
     "example": "日本語を練習します。",
     "kanji_search_results": [
       {
-        "kanji": "習",
-        "mean": "TẬP"
-      },
-      {
         "kanji": "練",
         "mean": "LUYỆN"
+      },
+      {
+        "kanji": "習",
+        "mean": "TẬP"
       }
     ]
   },
@@ -1112,12 +1112,12 @@
     "example": "東京に住んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "京",
-        "mean": "KINH"
-      },
-      {
         "kanji": "東",
         "mean": "ĐÔNG"
+      },
+      {
+        "kanji": "京",
+        "mean": "KINH"
       }
     ]
   },
@@ -1218,12 +1218,12 @@
     "example": "文化センターで勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "化",
-        "mean": "HÓA"
-      },
-      {
         "kanji": "文",
         "mean": "VĂN, VẤN"
+      },
+      {
+        "kanji": "化",
+        "mean": "HÓA"
       }
     ]
   },
@@ -1238,16 +1238,16 @@
     "example": "映画会に参加します。",
     "kanji_search_results": [
       {
+        "kanji": "映",
+        "mean": "ÁNH"
+      },
+      {
         "kanji": "画",
         "mean": "HỌA, HOẠCH"
       },
       {
         "kanji": "会",
         "mean": "HỘI, CỐI"
-      },
-      {
-        "kanji": "映",
-        "mean": "ÁNH"
       }
     ]
   }

--- a/data/lesson_5_vocabulary.json
+++ b/data/lesson_5_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今何時ですか。"
+    "example": "今何時ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      }
+    ]
   },
   {
     "japanese": "ごぜん",
@@ -17,7 +23,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "午前九時です。"
+    "example": "午前九時です。",
+    "kanji_search_results": [
+      {
+        "kanji": "午",
+        "mean": "NGỌ"
+      },
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      }
+    ]
   },
   {
     "japanese": "ごご",
@@ -27,7 +43,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "午後三時です。"
+    "example": "午後三時です。",
+    "kanji_search_results": [
+      {
+        "kanji": "午",
+        "mean": "NGỌ"
+      },
+      {
+        "kanji": "後",
+        "mean": "HẬU, HẤU"
+      }
+    ]
   },
   {
     "japanese": "－じ",
@@ -37,7 +63,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三時です。"
+    "example": "三時です。",
+    "kanji_search_results": [
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "－ふん",
@@ -47,7 +79,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三十分です。"
+    "example": "三十分です。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "－ぷん",
@@ -57,7 +95,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "五分です。"
+    "example": "五分です。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "－じはん",
@@ -67,7 +111,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三時半です。"
+    "example": "三時半です。",
+    "kanji_search_results": [
+      {
+        "kanji": "半",
+        "mean": "BÁN"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "なんじ",
@@ -77,7 +131,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何時ですか。"
+    "example": "何時ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "なんぷん",
@@ -87,7 +151,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何分ですか。"
+    "example": "何分ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "インターネット",
@@ -127,7 +201,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "education",
-    "example": "説明を聞きます。"
+    "example": "説明を聞きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "説",
+        "mean": "THUYẾT, DUYỆT, THUẾ"
+      },
+      {
+        "kanji": "明",
+        "mean": "MINH"
+      }
+    ]
   },
   {
     "japanese": "～かい",
@@ -137,7 +221,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "suffix",
-    "example": "説明会に参加します。"
+    "example": "説明会に参加します。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "せつめいかい",
@@ -147,7 +237,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "event",
-    "example": "説明会に参加します。"
+    "example": "説明会に参加します。",
+    "kanji_search_results": [
+      {
+        "kanji": "説",
+        "mean": "THUYẾT, DUYỆT, THUẾ"
+      },
+      {
+        "kanji": "明",
+        "mean": "MINH"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "パーティー",
@@ -167,7 +271,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "education",
-    "example": "文法を勉強します。"
+    "example": "文法を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "法",
+        "mean": "PHÁP"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "かいわ",
@@ -177,7 +291,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "education",
-    "example": "会話を練習します。"
+    "example": "会話を練習します。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "かんじ",
@@ -187,7 +311,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "education",
-    "example": "漢字を覚えます。"
+    "example": "漢字を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "字",
+        "mean": "TỰ"
+      },
+      {
+        "kanji": "漢",
+        "mean": "HÁN"
+      }
+    ]
   },
   {
     "japanese": "ていしょく",
@@ -197,7 +331,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "food",
-    "example": "定食を注文します。"
+    "example": "定食を注文します。",
+    "kanji_search_results": [
+      {
+        "kanji": "定",
+        "mean": "ĐỊNH, ĐÍNH"
+      },
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      }
+    ]
   },
   {
     "japanese": "アルバイト",
@@ -217,7 +361,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "object",
-    "example": "お風呂に入ります。"
+    "example": "お風呂に入ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "呂",
+        "mean": "LỮ, LÃ"
+      },
+      {
+        "kanji": "風",
+        "mean": "PHONG"
+      }
+    ]
   },
   {
     "japanese": "おすもうさん",
@@ -227,7 +381,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "person",
-    "example": "お相撲さんを見ます。"
+    "example": "お相撲さんを見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "撲",
+        "mean": "PHÁC, BẠC, PHỐC"
+      },
+      {
+        "kanji": "相",
+        "mean": "TƯƠNG, TƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "みなさん",
@@ -237,7 +401,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "person",
-    "example": "皆さん、こんにちは。"
+    "example": "皆さん、こんにちは。",
+    "kanji_search_results": [
+      {
+        "kanji": "皆",
+        "mean": "GIAI"
+      }
+    ]
   },
   {
     "japanese": "せんしゅう",
@@ -247,7 +417,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "先週映画を見ました。"
+    "example": "先週映画を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      }
+    ]
   },
   {
     "japanese": "こんしゅう",
@@ -257,7 +437,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今週忙しいです。"
+    "example": "今週忙しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      }
+    ]
   },
   {
     "japanese": "らいしゅう",
@@ -267,7 +457,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "来週休みです。"
+    "example": "来週休みです。",
+    "kanji_search_results": [
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      }
+    ]
   },
   {
     "japanese": "まいしゅう",
@@ -277,7 +477,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "毎週映画を見ます。"
+    "example": "毎週映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "毎",
+        "mean": "MỖI"
+      }
+    ]
   },
   {
     "japanese": "げつようび",
@@ -287,7 +497,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "月曜日に学校に行きます。"
+    "example": "月曜日に学校に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "かようび",
@@ -297,7 +521,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "火曜日に会議があります。"
+    "example": "火曜日に会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "火",
+        "mean": "HỎA"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "すいようび",
@@ -307,7 +545,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "水曜日に買い物をします。"
+    "example": "水曜日に買い物をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "水",
+        "mean": "THỦY"
+      }
+    ]
   },
   {
     "japanese": "もくようび",
@@ -317,7 +569,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "木曜日に映画を見ます。"
+    "example": "木曜日に映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "木",
+        "mean": "MỘC"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "きんようび",
@@ -327,7 +593,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "金曜日にパーティーをします。"
+    "example": "金曜日にパーティーをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "金",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "どようび",
@@ -337,7 +617,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "土曜日に休みます。"
+    "example": "土曜日に休みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "土",
+        "mean": "THỔ, ĐỘ, ĐỖ"
+      }
+    ]
   },
   {
     "japanese": "にちようび",
@@ -347,7 +641,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "日曜日に家族と過ごします。"
+    "example": "日曜日に家族と過ごします。",
+    "kanji_search_results": [
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "なんようび",
@@ -357,7 +661,21 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何曜日ですか。"
+    "example": "何曜日ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "曜",
+        "mean": "DIỆU"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "きのう",
@@ -367,7 +685,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "昨日映画を見ました。"
+    "example": "昨日映画を見ました。",
+    "kanji_search_results": [
+      {
+        "kanji": "昨",
+        "mean": "TẠC"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "おととい",
@@ -387,7 +715,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "朝早く起きます。"
+    "example": "朝早く起きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
+      }
+    ]
   },
   {
     "japanese": "けさ",
@@ -397,7 +731,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今朝コーヒーを飲みました。"
+    "example": "今朝コーヒーを飲みました。",
+    "kanji_search_results": [
+      {
+        "kanji": "朝",
+        "mean": "TRIÊU, TRIỀU"
+      },
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      }
+    ]
   },
   {
     "japanese": "ひる",
@@ -407,7 +751,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "昼ご飯を食べます。"
+    "example": "昼ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "昼",
+        "mean": "TRÚ"
+      }
+    ]
   },
   {
     "japanese": "ばん",
@@ -417,7 +767,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "晩ご飯を食べます。"
+    "example": "晩ご飯を食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "晩",
+        "mean": "VÃN"
+      }
+    ]
   },
   {
     "japanese": "よる",
@@ -427,7 +783,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "time",
-    "example": "夜テレビを見ます。"
+    "example": "夜テレビを見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "夜",
+        "mean": "DẠ"
+      }
+    ]
   },
   {
     "japanese": "おきます",
@@ -437,7 +799,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "毎朝六時に起きます。"
+    "example": "毎朝六時に起きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "起",
+        "mean": "KHỞI"
+      }
+    ]
   },
   {
     "japanese": "ねます",
@@ -447,7 +815,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "夜十時に寝ます。"
+    "example": "夜十時に寝ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "寝",
+        "mean": "TẨM"
+      }
+    ]
   },
   {
     "japanese": "べんきょうします",
@@ -457,7 +831,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "毎日勉強します。"
+    "example": "毎日勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "勉",
+        "mean": "MIỄN"
+      },
+      {
+        "kanji": "強",
+        "mean": "CƯỜNG, CƯỠNG"
+      }
+    ]
   },
   {
     "japanese": "けんきゅうします",
@@ -467,7 +851,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日本語を研究します。"
+    "example": "日本語を研究します。",
+    "kanji_search_results": [
+      {
+        "kanji": "研",
+        "mean": "NGHIÊN"
+      },
+      {
+        "kanji": "究",
+        "mean": "CỨU"
+      }
+    ]
   },
   {
     "japanese": "はたらきます",
@@ -477,7 +871,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "会社で働きます。"
+    "example": "会社で働きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "働",
+        "mean": "ĐỘNG"
+      }
+    ]
   },
   {
     "japanese": "およぎます",
@@ -487,7 +887,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "プールで泳ぎます。"
+    "example": "プールで泳ぎます。",
+    "kanji_search_results": [
+      {
+        "kanji": "泳",
+        "mean": "VỊNH"
+      }
+    ]
   },
   {
     "japanese": "おわります",
@@ -497,7 +903,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "授業が終わります。"
+    "example": "授業が終わります。",
+    "kanji_search_results": [
+      {
+        "kanji": "終",
+        "mean": "CHUNG"
+      }
+    ]
   },
   {
     "japanese": "はじまります",
@@ -507,7 +919,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "映画が始まります。"
+    "example": "映画が始まります。",
+    "kanji_search_results": [
+      {
+        "kanji": "始",
+        "mean": "THỦY, THÍ"
+      }
+    ]
   },
   {
     "japanese": "れんしゅうします",
@@ -517,7 +935,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日本語を練習します。"
+    "example": "日本語を練習します。",
+    "kanji_search_results": [
+      {
+        "kanji": "習",
+        "mean": "TẬP"
+      },
+      {
+        "kanji": "練",
+        "mean": "LUYỆN"
+      }
+    ]
   },
   {
     "japanese": "はいります",
@@ -527,7 +955,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お風呂に入ります。"
+    "example": "お風呂に入ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "入",
+        "mean": "NHẬP"
+      }
+    ]
   },
   {
     "japanese": "やすみます",
@@ -537,7 +971,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日曜日に休みます。"
+    "example": "日曜日に休みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "休",
+        "mean": "HƯU"
+      }
+    ]
   },
   {
     "japanese": "つくります",
@@ -547,7 +987,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "料理を作ります。"
+    "example": "料理を作ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "作",
+        "mean": "TÁC"
+      }
+    ]
   },
   {
     "japanese": "－さい",
@@ -557,7 +1003,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "number",
-    "example": "二十歳です。"
+    "example": "二十歳です。",
+    "kanji_search_results": [
+      {
+        "kanji": "歳",
+        "mean": "TUẾ"
+      }
+    ]
   },
   {
     "japanese": "なんさい",
@@ -567,7 +1019,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何歳ですか。"
+    "example": "何歳ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "歳",
+        "mean": "TUẾ"
+      }
+    ]
   },
   {
     "japanese": "～から",
@@ -647,7 +1109,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "place",
-    "example": "東京に住んでいます。"
+    "example": "東京に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "京",
+        "mean": "KINH"
+      },
+      {
+        "kanji": "東",
+        "mean": "ĐÔNG"
+      }
+    ]
   },
   {
     "japanese": "シカゴ",
@@ -727,7 +1199,13 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "place",
-    "example": "すばる山に登ります。"
+    "example": "すばる山に登ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "山",
+        "mean": "SAN, SƠN"
+      }
+    ]
   },
   {
     "japanese": "ぶんかセンター",
@@ -737,7 +1215,17 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "place",
-    "example": "文化センターで勉強します。"
+    "example": "文化センターで勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "化",
+        "mean": "HÓA"
+      },
+      {
+        "kanji": "文",
+        "mean": "VĂN, VẤN"
+      }
+    ]
   },
   {
     "japanese": "えいがかい",
@@ -747,6 +1235,20 @@
     "lesson": 5,
     "difficulty": "beginner",
     "category": "event",
-    "example": "映画会に参加します。"
+    "example": "映画会に参加します。",
+    "kanji_search_results": [
+      {
+        "kanji": "画",
+        "mean": "HỌA, HOẠCH"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "映",
+        "mean": "ÁNH"
+      }
+    ]
   }
 ]

--- a/data/lesson_6_vocabulary.json
+++ b/data/lesson_6_vocabulary.json
@@ -14,12 +14,12 @@
         "mean": "ĐẢN"
       },
       {
-        "kanji": "日",
-        "mean": "NHẬT, NHỰT"
-      },
-      {
         "kanji": "生",
         "mean": "SANH, SINH"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
       }
     ]
   },
@@ -44,16 +44,16 @@
     "example": "飛行機で旅行します。",
     "kanji_search_results": [
       {
+        "kanji": "飛",
+        "mean": "PHI"
+      },
+      {
         "kanji": "行",
         "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       },
       {
         "kanji": "機",
         "mean": "KI, CƠ"
-      },
-      {
-        "kanji": "飛",
-        "mean": "PHI"
       }
     ]
   },
@@ -88,16 +88,16 @@
     "example": "自転車で買い物に行きます。",
     "kanji_search_results": [
       {
+        "kanji": "自",
+        "mean": "TỰ"
+      },
+      {
         "kanji": "転",
         "mean": "CHUYỂN"
       },
       {
         "kanji": "車",
         "mean": "XA"
-      },
-      {
-        "kanji": "自",
-        "mean": "TỰ"
       }
     ]
   },
@@ -112,16 +112,16 @@
     "example": "地下鉄で東京に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "鉄",
-        "mean": "THIẾT"
-      },
-      {
         "kanji": "地",
         "mean": "ĐỊA"
       },
       {
         "kanji": "下",
         "mean": "HẠ, HÁ"
+      },
+      {
+        "kanji": "鉄",
+        "mean": "THIẾT"
       }
     ]
   },
@@ -272,12 +272,12 @@
     "example": "新幹線で大阪に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "幹",
-        "mean": "CÁN, CAN"
-      },
-      {
         "kanji": "新",
         "mean": "TÂN"
+      },
+      {
+        "kanji": "幹",
+        "mean": "CÁN, CAN"
       },
       {
         "kanji": "線",
@@ -296,12 +296,12 @@
     "example": "温泉に入ります。",
     "kanji_search_results": [
       {
-        "kanji": "泉",
-        "mean": "TUYỀN, TOÀN"
-      },
-      {
         "kanji": "温",
         "mean": "ÔN, UẨN"
+      },
+      {
+        "kanji": "泉",
+        "mean": "TUYỀN, TOÀN"
       }
     ]
   },
@@ -926,12 +926,12 @@
     "example": "一緒に映画を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "緒",
-        "mean": "TỰ"
-      },
-      {
         "kanji": "一",
         "mean": "NHẤT"
+      },
+      {
+        "kanji": "緒",
+        "mean": "TỰ"
       }
     ]
   },
@@ -946,12 +946,12 @@
     "example": "一人で旅行します。",
     "kanji_search_results": [
       {
-        "kanji": "人",
-        "mean": "NHÂN"
-      },
-      {
         "kanji": "一",
         "mean": "NHẤT"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
       }
     ]
   },
@@ -966,12 +966,12 @@
     "example": "今度一緒に行きましょう。",
     "kanji_search_results": [
       {
-        "kanji": "度",
-        "mean": "ĐỘ, ĐẠC"
-      },
-      {
         "kanji": "今",
         "mean": "KIM"
+      },
+      {
+        "kanji": "度",
+        "mean": "ĐỘ, ĐẠC"
       }
     ]
   },
@@ -1036,12 +1036,12 @@
     "example": "北海道でスキーをします。",
     "kanji_search_results": [
       {
-        "kanji": "海",
-        "mean": "HẢI"
-      },
-      {
         "kanji": "北",
         "mean": "BẮC"
+      },
+      {
+        "kanji": "海",
+        "mean": "HẢI"
       },
       {
         "kanji": "道",
@@ -1060,12 +1060,12 @@
     "example": "札幌で雪祭りを見ます。",
     "kanji_search_results": [
       {
-        "kanji": "幌",
-        "mean": "HOẢNG"
-      },
-      {
         "kanji": "札",
         "mean": "TRÁT"
+      },
+      {
+        "kanji": "幌",
+        "mean": "HOẢNG"
       }
     ]
   },
@@ -1120,12 +1120,12 @@
     "example": "名古屋で味噌カツを食べます。",
     "kanji_search_results": [
       {
-        "kanji": "古",
-        "mean": "CỔ"
-      },
-      {
         "kanji": "名",
         "mean": "DANH"
+      },
+      {
+        "kanji": "古",
+        "mean": "CỔ"
       },
       {
         "kanji": "屋",
@@ -1184,12 +1184,12 @@
     "example": "広島で原爆ドームを見学します。",
     "kanji_search_results": [
       {
-        "kanji": "島",
-        "mean": "ĐẢO"
-      },
-      {
         "kanji": "広",
         "mean": "QUẢNG"
+      },
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
       }
     ]
   },
@@ -1204,12 +1204,12 @@
     "example": "別府で温泉に入ります。",
     "kanji_search_results": [
       {
-        "kanji": "府",
-        "mean": "PHỦ"
-      },
-      {
         "kanji": "別",
         "mean": "BIỆT"
+      },
+      {
+        "kanji": "府",
+        "mean": "PHỦ"
       }
     ]
   },
@@ -1228,12 +1228,12 @@
         "mean": "ĐẠI, THÁI"
       },
       {
-        "kanji": "城",
-        "mean": "THÀNH"
-      },
-      {
         "kanji": "阪",
         "mean": "PHẢN"
+      },
+      {
+        "kanji": "城",
+        "mean": "THÀNH"
       }
     ]
   },
@@ -1248,12 +1248,12 @@
     "example": "原爆ドームを見学します。",
     "kanji_search_results": [
       {
-        "kanji": "爆",
-        "mean": "BẠO, BẠC, BỘC"
-      },
-      {
         "kanji": "原",
         "mean": "NGUYÊN"
+      },
+      {
+        "kanji": "爆",
+        "mean": "BẠO, BẠC, BỘC"
       }
     ]
   },
@@ -1268,8 +1268,8 @@
     "example": "田中正男さんに会います。",
     "kanji_search_results": [
       {
-        "kanji": "男",
-        "mean": "NAM"
+        "kanji": "田",
+        "mean": "ĐIỀN"
       },
       {
         "kanji": "中",
@@ -1280,8 +1280,8 @@
         "mean": "CHÁNH, CHÍNH"
       },
       {
-        "kanji": "田",
-        "mean": "ĐIỀN"
+        "kanji": "男",
+        "mean": "NAM"
       }
     ]
   }

--- a/data/lesson_6_vocabulary.json
+++ b/data/lesson_6_vocabulary.json
@@ -7,7 +7,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "event",
-    "example": "誕生日パーティーをします。"
+    "example": "誕生日パーティーをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "誕",
+        "mean": "ĐẢN"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "バス",
@@ -27,7 +41,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "飛行機で旅行します。"
+    "example": "飛行機で旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "飛",
+        "mean": "PHI"
+      }
+    ]
   },
   {
     "japanese": "でんしゃ",
@@ -37,7 +65,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "電車で通勤します。"
+    "example": "電車で通勤します。",
+    "kanji_search_results": [
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "車",
+        "mean": "XA"
+      }
+    ]
   },
   {
     "japanese": "じてんしゃ",
@@ -47,7 +85,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "自転車で買い物に行きます。"
+    "example": "自転車で買い物に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "転",
+        "mean": "CHUYỂN"
+      },
+      {
+        "kanji": "車",
+        "mean": "XA"
+      },
+      {
+        "kanji": "自",
+        "mean": "TỰ"
+      }
+    ]
   },
   {
     "japanese": "ちかてつ",
@@ -57,7 +109,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "地下鉄で東京に行きます。"
+    "example": "地下鉄で東京に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "鉄",
+        "mean": "THIẾT"
+      },
+      {
+        "kanji": "地",
+        "mean": "ĐỊA"
+      },
+      {
+        "kanji": "下",
+        "mean": "HẠ, HÁ"
+      }
+    ]
   },
   {
     "japanese": "どうぶつえん",
@@ -67,7 +133,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "動物園でパンダを見ます。"
+    "example": "動物園でパンダを見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      },
+      {
+        "kanji": "園",
+        "mean": "VIÊN"
+      }
+    ]
   },
   {
     "japanese": "パンダ",
@@ -127,7 +207,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "event",
-    "example": "お祭りに行きます。"
+    "example": "お祭りに行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "祭",
+        "mean": "TẾ, SÁI"
+      }
+    ]
   },
   {
     "japanese": "バイク",
@@ -147,7 +233,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "花火を見に行きます。"
+    "example": "花火を見に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "花",
+        "mean": "HOA"
+      },
+      {
+        "kanji": "火",
+        "mean": "HỎA"
+      }
+    ]
   },
   {
     "japanese": "てら",
@@ -157,7 +253,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "お寺を参拝します。"
+    "example": "お寺を参拝します。",
+    "kanji_search_results": [
+      {
+        "kanji": "寺",
+        "mean": "TỰ"
+      }
+    ]
   },
   {
     "japanese": "しんかんせん",
@@ -167,7 +269,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "新幹線で大阪に行きます。"
+    "example": "新幹線で大阪に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "幹",
+        "mean": "CÁN, CAN"
+      },
+      {
+        "kanji": "新",
+        "mean": "TÂN"
+      },
+      {
+        "kanji": "線",
+        "mean": "TUYẾN"
+      }
+    ]
   },
   {
     "japanese": "おんせん",
@@ -177,7 +293,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "温泉に入ります。"
+    "example": "温泉に入ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "泉",
+        "mean": "TUYỀN, TOÀN"
+      },
+      {
+        "kanji": "温",
+        "mean": "ÔN, UẨN"
+      }
+    ]
   },
   {
     "japanese": "ふね",
@@ -187,7 +313,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "transportation",
-    "example": "船で旅行します。"
+    "example": "船で旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "船",
+        "mean": "THUYỀN"
+      }
+    ]
   },
   {
     "japanese": "こうこうせい",
@@ -197,7 +329,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "person",
-    "example": "高校生の時、よく勉強しました。"
+    "example": "高校生の時、よく勉強しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "高",
+        "mean": "CAO"
+      },
+      {
+        "kanji": "校",
+        "mean": "GIÁO, HIỆU, HÀO"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "しゅうまつ",
@@ -207,7 +353,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "週末に映画を見ます。"
+    "example": "週末に映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "週",
+        "mean": "CHU"
+      },
+      {
+        "kanji": "末",
+        "mean": "MẠT"
+      }
+    ]
   },
   {
     "japanese": "なつやすみ",
@@ -217,7 +373,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "夏休みに旅行します。"
+    "example": "夏休みに旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "夏",
+        "mean": "HẠ, GIẠ, GIÁ"
+      },
+      {
+        "kanji": "休",
+        "mean": "HƯU"
+      }
+    ]
   },
   {
     "japanese": "ふゆやすみ",
@@ -227,7 +393,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "冬休みにスキーをします。"
+    "example": "冬休みにスキーをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "冬",
+        "mean": "ĐÔNG"
+      },
+      {
+        "kanji": "休",
+        "mean": "HƯU"
+      }
+    ]
   },
   {
     "japanese": "らいげつ",
@@ -237,7 +413,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "来月日本に行きます。"
+    "example": "来月日本に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "こんげつ",
@@ -247,7 +433,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今月忙しいです。"
+    "example": "今月忙しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "せんげつ",
@@ -257,7 +453,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "先月結婚しました。"
+    "example": "先月結婚しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "先",
+        "mean": "TIÊN, TIẾN"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "きょねん",
@@ -267,7 +473,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "去年大学を卒業しました。"
+    "example": "去年大学を卒業しました。",
+    "kanji_search_results": [
+      {
+        "kanji": "去",
+        "mean": "KHỨ, KHU"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "ことし",
@@ -277,7 +493,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今年新しい仕事を始めます。"
+    "example": "今年新しい仕事を始めます。",
+    "kanji_search_results": [
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "らいねん",
@@ -287,7 +513,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "来年結婚します。"
+    "example": "来年結婚します。",
+    "kanji_search_results": [
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      },
+      {
+        "kanji": "年",
+        "mean": "NIÊN"
+      }
+    ]
   },
   {
     "japanese": "いきます",
@@ -297,7 +533,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "学校に行きます。"
+    "example": "学校に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      }
+    ]
   },
   {
     "japanese": "かえります",
@@ -307,7 +549,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "家に帰ります。"
+    "example": "家に帰ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "帰",
+        "mean": "QUY"
+      }
+    ]
   },
   {
     "japanese": "きます",
@@ -317,7 +565,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日本に来ます。"
+    "example": "日本に来ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "来",
+        "mean": "LAI, LÃI"
+      }
+    ]
   },
   {
     "japanese": "しょくじします",
@@ -327,7 +581,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "家族と食事します。"
+    "example": "家族と食事します。",
+    "kanji_search_results": [
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      },
+      {
+        "kanji": "事",
+        "mean": "SỰ"
+      }
+    ]
   },
   {
     "japanese": "あいます",
@@ -337,7 +601,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "友達に会います。"
+    "example": "友達に会います。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      }
+    ]
   },
   {
     "japanese": "－がつ",
@@ -347,7 +617,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三月に卒業します。"
+    "example": "三月に卒業します。",
+    "kanji_search_results": [
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "なんがつ",
@@ -357,7 +633,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何月に日本に行きますか。"
+    "example": "何月に日本に行きますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "月",
+        "mean": "NGUYỆT"
+      }
+    ]
   },
   {
     "japanese": "－にち",
@@ -367,7 +653,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "十五日に会議があります。"
+    "example": "十五日に会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "なんにち",
@@ -377,7 +669,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何日に来ますか。"
+    "example": "何日に来ますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "ついたち",
@@ -387,7 +689,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "一月一日は元旦です。"
+    "example": "一月一日は元旦です。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "ふつか",
@@ -397,7 +705,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "二日間旅行します。"
+    "example": "二日間旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "みっか",
@@ -407,7 +721,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "三日間休みます。"
+    "example": "三日間休みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "よっか",
@@ -417,7 +737,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "四日間勉強します。"
+    "example": "四日間勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "いつか",
@@ -427,7 +753,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "五日間会議があります。"
+    "example": "五日間会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "むいか",
@@ -437,7 +769,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "六日間旅行します。"
+    "example": "六日間旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "なのか",
@@ -447,7 +785,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "七日間休みます。"
+    "example": "七日間休みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "ようか",
@@ -457,7 +801,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "八日間勉強します。"
+    "example": "八日間勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "ここのか",
@@ -467,7 +817,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "九日間会議があります。"
+    "example": "九日間会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "とおか",
@@ -477,7 +833,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "十日間旅行します。"
+    "example": "十日間旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "じゅうよっか",
@@ -487,7 +849,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "十四日に誕生日です。"
+    "example": "十四日に誕生日です。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "はつか",
@@ -497,7 +865,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "二十日に会議があります。"
+    "example": "二十日に会議があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "にじゅうよっか",
@@ -507,7 +881,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "二十四日に旅行します。"
+    "example": "二十四日に旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "日",
+        "mean": "NHẬT, NHỰT"
+      }
+    ]
   },
   {
     "japanese": "いつ",
@@ -527,7 +907,13 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "歩いて学校に行きます。"
+    "example": "歩いて学校に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "歩",
+        "mean": "BỘ"
+      }
+    ]
   },
   {
     "japanese": "いっしょに",
@@ -537,7 +923,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "一緒に映画を見ます。"
+    "example": "一緒に映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "緒",
+        "mean": "TỰ"
+      },
+      {
+        "kanji": "一",
+        "mean": "NHẤT"
+      }
+    ]
   },
   {
     "japanese": "ひとりで",
@@ -547,7 +943,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "一人で旅行します。"
+    "example": "一人で旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      },
+      {
+        "kanji": "一",
+        "mean": "NHẤT"
+      }
+    ]
   },
   {
     "japanese": "こんど",
@@ -557,7 +963,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "time",
-    "example": "今度一緒に行きましょう。"
+    "example": "今度一緒に行きましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "度",
+        "mean": "ĐỘ, ĐẠC"
+      },
+      {
+        "kanji": "今",
+        "mean": "KIM"
+      }
+    ]
   },
   {
     "japanese": "ええ",
@@ -617,7 +1033,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "北海道でスキーをします。"
+    "example": "北海道でスキーをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "海",
+        "mean": "HẢI"
+      },
+      {
+        "kanji": "北",
+        "mean": "BẮC"
+      },
+      {
+        "kanji": "道",
+        "mean": "ĐẠO, ĐÁO"
+      }
+    ]
   },
   {
     "japanese": "さっぽろ",
@@ -627,7 +1057,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "札幌で雪祭りを見ます。"
+    "example": "札幌で雪祭りを見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "幌",
+        "mean": "HOẢNG"
+      },
+      {
+        "kanji": "札",
+        "mean": "TRÁT"
+      }
+    ]
   },
   {
     "japanese": "せんだい",
@@ -637,7 +1077,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "仙台で牛タンを食べます。"
+    "example": "仙台で牛タンを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "仙",
+        "mean": "TIÊN"
+      },
+      {
+        "kanji": "台",
+        "mean": "THAI, ĐÀI, DI"
+      }
+    ]
   },
   {
     "japanese": "よこはま",
@@ -647,7 +1097,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "横浜で中華街を散歩します。"
+    "example": "横浜で中華街を散歩します。",
+    "kanji_search_results": [
+      {
+        "kanji": "横",
+        "mean": "HOÀNH, HOẠNH, QUÁNG"
+      },
+      {
+        "kanji": "浜",
+        "mean": "BANH"
+      }
+    ]
   },
   {
     "japanese": "なごや",
@@ -657,7 +1117,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "名古屋で味噌カツを食べます。"
+    "example": "名古屋で味噌カツを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "古",
+        "mean": "CỔ"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      },
+      {
+        "kanji": "屋",
+        "mean": "ỐC"
+      }
+    ]
   },
   {
     "japanese": "きょうと",
@@ -667,7 +1141,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "京都でお寺を参拝します。"
+    "example": "京都でお寺を参拝します。",
+    "kanji_search_results": [
+      {
+        "kanji": "京",
+        "mean": "KINH"
+      },
+      {
+        "kanji": "都",
+        "mean": "ĐÔ"
+      }
+    ]
   },
   {
     "japanese": "おおさか",
@@ -677,7 +1161,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "大阪でたこ焼きを食べます。"
+    "example": "大阪でたこ焼きを食べます。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "阪",
+        "mean": "PHẢN"
+      }
+    ]
   },
   {
     "japanese": "ひろしま",
@@ -687,7 +1181,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "広島で原爆ドームを見学します。"
+    "example": "広島で原爆ドームを見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "島",
+        "mean": "ĐẢO"
+      },
+      {
+        "kanji": "広",
+        "mean": "QUẢNG"
+      }
+    ]
   },
   {
     "japanese": "べっぷ",
@@ -697,7 +1201,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "別府で温泉に入ります。"
+    "example": "別府で温泉に入ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "府",
+        "mean": "PHỦ"
+      },
+      {
+        "kanji": "別",
+        "mean": "BIỆT"
+      }
+    ]
   },
   {
     "japanese": "おおさかじょう",
@@ -707,7 +1221,21 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "大阪城を見学します。"
+    "example": "大阪城を見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "城",
+        "mean": "THÀNH"
+      },
+      {
+        "kanji": "阪",
+        "mean": "PHẢN"
+      }
+    ]
   },
   {
     "japanese": "げんばくドーム",
@@ -717,7 +1245,17 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "place",
-    "example": "原爆ドームを見学します。"
+    "example": "原爆ドームを見学します。",
+    "kanji_search_results": [
+      {
+        "kanji": "爆",
+        "mean": "BẠO, BẠC, BỘC"
+      },
+      {
+        "kanji": "原",
+        "mean": "NGUYÊN"
+      }
+    ]
   },
   {
     "japanese": "たなか まさお",
@@ -727,6 +1265,24 @@
     "lesson": 6,
     "difficulty": "beginner",
     "category": "person",
-    "example": "田中正男さんに会います。"
+    "example": "田中正男さんに会います。",
+    "kanji_search_results": [
+      {
+        "kanji": "男",
+        "mean": "NAM"
+      },
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      },
+      {
+        "kanji": "正",
+        "mean": "CHÁNH, CHÍNH"
+      },
+      {
+        "kanji": "田",
+        "mean": "ĐIỀN"
+      }
+    ]
   }
 ]

--- a/data/lesson_7_vocabulary.json
+++ b/data/lesson_7_vocabulary.json
@@ -7,7 +7,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "きれいな花です。"
+    "example": "きれいな花です。",
+    "kanji_search_results": [
+      {
+        "kanji": "花",
+        "mean": "HOA"
+      }
+    ]
   },
   {
     "japanese": "へや",
@@ -17,7 +23,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "place",
-    "example": "部屋が広いです。"
+    "example": "部屋が広いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "部",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "屋",
+        "mean": "ỐC"
+      }
+    ]
   },
   {
     "japanese": "アパート",
@@ -47,7 +63,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "food",
-    "example": "おいしい食べ物です。"
+    "example": "おいしい食べ物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "食",
+        "mean": "THỰC, TỰ"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "せいかつ",
@@ -57,7 +83,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "noun",
-    "example": "生活が忙しいです。"
+    "example": "生活が忙しいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "活",
+        "mean": "HOẠT, QUẠT"
+      },
+      {
+        "kanji": "生",
+        "mean": "SANH, SINH"
+      }
+    ]
   },
   {
     "japanese": "やま",
@@ -67,7 +103,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "高い山です。"
+    "example": "高い山です。",
+    "kanji_search_results": [
+      {
+        "kanji": "山",
+        "mean": "SAN, SƠN"
+      }
+    ]
   },
   {
     "japanese": "うみ",
@@ -77,7 +119,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "青い海です。"
+    "example": "青い海です。",
+    "kanji_search_results": [
+      {
+        "kanji": "海",
+        "mean": "HẢI"
+      }
+    ]
   },
   {
     "japanese": "バドミントン",
@@ -107,7 +155,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "桜がきれいです。"
+    "example": "桜がきれいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "桜",
+        "mean": "ANH"
+      }
+    ]
   },
   {
     "japanese": "バナナ",
@@ -127,7 +181,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "place",
-    "example": "静かな町です。"
+    "example": "静かな町です。",
+    "kanji_search_results": [
+      {
+        "kanji": "町",
+        "mean": "ĐINH"
+      }
+    ]
   },
   {
     "japanese": "ゲームソフト",
@@ -177,7 +237,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "object",
-    "example": "きれいな写真です。"
+    "example": "きれいな写真です。",
+    "kanji_search_results": [
+      {
+        "kanji": "写",
+        "mean": "TẢ"
+      },
+      {
+        "kanji": "真",
+        "mean": "CHÂN"
+      }
+    ]
   },
   {
     "japanese": "たてもの",
@@ -187,7 +257,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "place",
-    "example": "高い建物です。"
+    "example": "高い建物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "建",
+        "mean": "KIẾN, KIỂN"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "おおきい",
@@ -197,7 +277,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "大きい家です。"
+    "example": "大きい家です。",
+    "kanji_search_results": [
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   },
   {
     "japanese": "ちいさい",
@@ -207,7 +293,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "小さい車です。"
+    "example": "小さい車です。",
+    "kanji_search_results": [
+      {
+        "kanji": "小",
+        "mean": "TIỂU"
+      }
+    ]
   },
   {
     "japanese": "あたらしい",
@@ -217,7 +309,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "新しい本です。"
+    "example": "新しい本です。",
+    "kanji_search_results": [
+      {
+        "kanji": "新",
+        "mean": "TÂN"
+      }
+    ]
   },
   {
     "japanese": "ふるい",
@@ -227,7 +325,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "古い建物です。"
+    "example": "古い建物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "古",
+        "mean": "CỔ"
+      }
+    ]
   },
   {
     "japanese": "おもしろい",
@@ -237,7 +341,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "面白い映画です。"
+    "example": "面白い映画です。",
+    "kanji_search_results": [
+      {
+        "kanji": "白",
+        "mean": "BẠCH"
+      },
+      {
+        "kanji": "面",
+        "mean": "DIỆN, MIẾN"
+      }
+    ]
   },
   {
     "japanese": "たかい",
@@ -247,7 +361,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "高い山です。"
+    "example": "高い山です。",
+    "kanji_search_results": [
+      {
+        "kanji": "高",
+        "mean": "CAO"
+      }
+    ]
   },
   {
     "japanese": "ひくい",
@@ -257,7 +377,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "低い建物です。"
+    "example": "低い建物です。",
+    "kanji_search_results": [
+      {
+        "kanji": "低",
+        "mean": "ĐÊ"
+      }
+    ]
   },
   {
     "japanese": "やすい",
@@ -267,7 +393,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "安い服です。"
+    "example": "安い服です。",
+    "kanji_search_results": [
+      {
+        "kanji": "安",
+        "mean": "AN, YÊN"
+      }
+    ]
   },
   {
     "japanese": "たのしい",
@@ -277,7 +409,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "楽しい旅行です。"
+    "example": "楽しい旅行です。",
+    "kanji_search_results": [
+      {
+        "kanji": "楽",
+        "mean": "LẠC, NHẠC"
+      }
+    ]
   },
   {
     "japanese": "いい",
@@ -307,7 +445,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "難しい問題です。"
+    "example": "難しい問題です。",
+    "kanji_search_results": [
+      {
+        "kanji": "難",
+        "mean": "NAN, NẠN"
+      }
+    ]
   },
   {
     "japanese": "あおい",
@@ -317,7 +461,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "青い空です。"
+    "example": "青い空です。",
+    "kanji_search_results": [
+      {
+        "kanji": "青",
+        "mean": "THANH"
+      }
+    ]
   },
   {
     "japanese": "くろい",
@@ -327,7 +477,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "黒い車です。"
+    "example": "黒い車です。",
+    "kanji_search_results": [
+      {
+        "kanji": "黒",
+        "mean": "HẮC"
+      }
+    ]
   },
   {
     "japanese": "しろい",
@@ -337,7 +493,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "白い花です。"
+    "example": "白い花です。",
+    "kanji_search_results": [
+      {
+        "kanji": "白",
+        "mean": "BẠCH"
+      }
+    ]
   },
   {
     "japanese": "あかい",
@@ -347,7 +509,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "赤い花です。"
+    "example": "赤い花です。",
+    "kanji_search_results": [
+      {
+        "kanji": "赤",
+        "mean": "XÍCH, THÍCH"
+      }
+    ]
   },
   {
     "japanese": "ひろい",
@@ -357,7 +525,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "広い部屋です。"
+    "example": "広い部屋です。",
+    "kanji_search_results": [
+      {
+        "kanji": "広",
+        "mean": "QUẢNG"
+      }
+    ]
   },
   {
     "japanese": "せまい",
@@ -367,7 +541,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "狭い道です。"
+    "example": "狭い道です。",
+    "kanji_search_results": [
+      {
+        "kanji": "狭",
+        "mean": "HIỆP"
+      }
+    ]
   },
   {
     "japanese": "げんき",
@@ -377,7 +557,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "元気な人です。"
+    "example": "元気な人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      },
+      {
+        "kanji": "元",
+        "mean": "NGUYÊN"
+      }
+    ]
   },
   {
     "japanese": "しんせつ",
@@ -387,7 +577,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "親切な人です。"
+    "example": "親切な人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
+      },
+      {
+        "kanji": "親",
+        "mean": "THÂN, THẤN"
+      }
+    ]
   },
   {
     "japanese": "かんたん",
@@ -397,7 +597,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "簡単な問題です。"
+    "example": "簡単な問題です。",
+    "kanji_search_results": [
+      {
+        "kanji": "簡",
+        "mean": "GIẢN"
+      },
+      {
+        "kanji": "単",
+        "mean": "ĐƠN"
+      }
+    ]
   },
   {
     "japanese": "きれい",
@@ -427,7 +637,13 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "静かな場所です。"
+    "example": "静かな場所です。",
+    "kanji_search_results": [
+      {
+        "kanji": "静",
+        "mean": "TĨNH"
+      }
+    ]
   },
   {
     "japanese": "べんり",
@@ -437,7 +653,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "便利な道具です。"
+    "example": "便利な道具です。",
+    "kanji_search_results": [
+      {
+        "kanji": "便",
+        "mean": "TIỆN"
+      },
+      {
+        "kanji": "利",
+        "mean": "LỢI"
+      }
+    ]
   },
   {
     "japanese": "ゆうめい",
@@ -447,7 +673,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "有名な人です。"
+    "example": "有名な人です。",
+    "kanji_search_results": [
+      {
+        "kanji": "有",
+        "mean": "HỮU, DỰU"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      }
+    ]
   },
   {
     "japanese": "たいへん",
@@ -457,7 +693,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "大変な仕事です。"
+    "example": "大変な仕事です。",
+    "kanji_search_results": [
+      {
+        "kanji": "変",
+        "mean": "BIẾN"
+      },
+      {
+        "kanji": "大",
+        "mean": "ĐẠI, THÁI"
+      }
+    ]
   },
   {
     "japanese": "どう",
@@ -557,7 +803,21 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "place",
-    "example": "富士山が高いです。"
+    "example": "富士山が高いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "富",
+        "mean": "PHÚ"
+      },
+      {
+        "kanji": "山",
+        "mean": "SAN, SƠN"
+      },
+      {
+        "kanji": "士",
+        "mean": "SĨ"
+      }
+    ]
   },
   {
     "japanese": "ウィーン",
@@ -597,7 +857,21 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "い形容詞を勉強します。"
+    "example": "い形容詞を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "容",
+        "mean": "DUNG, DONG"
+      }
+    ]
   },
   {
     "japanese": "なけいようし",
@@ -607,7 +881,21 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "な形容詞を覚えます。"
+    "example": "な形容詞を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "容",
+        "mean": "DUNG, DONG"
+      }
+    ]
   },
   {
     "japanese": "けいようし",
@@ -617,7 +905,21 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "形容詞の使い方を学びます。"
+    "example": "形容詞の使い方を学びます。",
+    "kanji_search_results": [
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
+      },
+      {
+        "kanji": "形",
+        "mean": "HÌNH"
+      },
+      {
+        "kanji": "容",
+        "mean": "DUNG, DONG"
+      }
+    ]
   },
   {
     "japanese": "めいし",
@@ -627,7 +929,17 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "名詞を覚えます。"
+    "example": "名詞を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      }
+    ]
   },
   {
     "japanese": "どうし",
@@ -637,6 +949,16 @@
     "lesson": 7,
     "difficulty": "beginner",
     "category": "grammar",
-    "example": "動詞を勉強します。"
+    "example": "動詞を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
+      },
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
+      }
+    ]
   }
 ]

--- a/data/lesson_7_vocabulary.json
+++ b/data/lesson_7_vocabulary.json
@@ -86,12 +86,12 @@
     "example": "生活が忙しいです。",
     "kanji_search_results": [
       {
-        "kanji": "活",
-        "mean": "HOẠT, QUẠT"
-      },
-      {
         "kanji": "生",
         "mean": "SANH, SINH"
+      },
+      {
+        "kanji": "活",
+        "mean": "HOẠT, QUẠT"
       }
     ]
   },
@@ -344,12 +344,12 @@
     "example": "面白い映画です。",
     "kanji_search_results": [
       {
-        "kanji": "白",
-        "mean": "BẠCH"
-      },
-      {
         "kanji": "面",
         "mean": "DIỆN, MIẾN"
+      },
+      {
+        "kanji": "白",
+        "mean": "BẠCH"
       }
     ]
   },
@@ -560,12 +560,12 @@
     "example": "元気な人です。",
     "kanji_search_results": [
       {
-        "kanji": "気",
-        "mean": "KHÍ"
-      },
-      {
         "kanji": "元",
         "mean": "NGUYÊN"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
       }
     ]
   },
@@ -580,12 +580,12 @@
     "example": "親切な人です。",
     "kanji_search_results": [
       {
-        "kanji": "切",
-        "mean": "THIẾT, THẾ"
-      },
-      {
         "kanji": "親",
         "mean": "THÂN, THẤN"
+      },
+      {
+        "kanji": "切",
+        "mean": "THIẾT, THẾ"
       }
     ]
   },
@@ -696,12 +696,12 @@
     "example": "大変な仕事です。",
     "kanji_search_results": [
       {
-        "kanji": "変",
-        "mean": "BIẾN"
-      },
-      {
         "kanji": "大",
         "mean": "ĐẠI, THÁI"
+      },
+      {
+        "kanji": "変",
+        "mean": "BIẾN"
       }
     ]
   },
@@ -810,12 +810,12 @@
         "mean": "PHÚ"
       },
       {
-        "kanji": "山",
-        "mean": "SAN, SƠN"
-      },
-      {
         "kanji": "士",
         "mean": "SĨ"
+      },
+      {
+        "kanji": "山",
+        "mean": "SAN, SƠN"
       }
     ]
   },
@@ -860,16 +860,16 @@
     "example": "い形容詞を勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "詞",
-        "mean": "TỪ"
-      },
-      {
         "kanji": "形",
         "mean": "HÌNH"
       },
       {
         "kanji": "容",
         "mean": "DUNG, DONG"
+      },
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
       }
     ]
   },
@@ -884,16 +884,16 @@
     "example": "な形容詞を覚えます。",
     "kanji_search_results": [
       {
-        "kanji": "詞",
-        "mean": "TỪ"
-      },
-      {
         "kanji": "形",
         "mean": "HÌNH"
       },
       {
         "kanji": "容",
         "mean": "DUNG, DONG"
+      },
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
       }
     ]
   },
@@ -908,16 +908,16 @@
     "example": "形容詞の使い方を学びます。",
     "kanji_search_results": [
       {
-        "kanji": "詞",
-        "mean": "TỪ"
-      },
-      {
         "kanji": "形",
         "mean": "HÌNH"
       },
       {
         "kanji": "容",
         "mean": "DUNG, DONG"
+      },
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
       }
     ]
   },
@@ -932,12 +932,12 @@
     "example": "名詞を覚えます。",
     "kanji_search_results": [
       {
-        "kanji": "詞",
-        "mean": "TỪ"
-      },
-      {
         "kanji": "名",
         "mean": "DANH"
+      },
+      {
+        "kanji": "詞",
+        "mean": "TỪ"
       }
     ]
   },

--- a/data/lesson_8_vocabulary.json
+++ b/data/lesson_8_vocabulary.json
@@ -122,12 +122,12 @@
     "example": "子供が遊んでいます。",
     "kanji_search_results": [
       {
-        "kanji": "供",
-        "mean": "CUNG"
-      },
-      {
         "kanji": "子",
         "mean": "TỬ, TÍ"
+      },
+      {
+        "kanji": "供",
+        "mean": "CUNG"
       }
     ]
   },
@@ -174,24 +174,24 @@
     "example": "自動販売機でジュースを買います。",
     "kanji_search_results": [
       {
+        "kanji": "自",
+        "mean": "TỰ"
+      },
+      {
         "kanji": "動",
         "mean": "ĐỘNG"
-      },
-      {
-        "kanji": "機",
-        "mean": "KI, CƠ"
-      },
-      {
-        "kanji": "売",
-        "mean": "MẠI"
       },
       {
         "kanji": "販",
         "mean": "PHIẾN, PHÁN"
       },
       {
-        "kanji": "自",
-        "mean": "TỰ"
+        "kanji": "売",
+        "mean": "MẠI"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
       }
     ]
   },
@@ -350,12 +350,12 @@
     "example": "電話をかけます。",
     "kanji_search_results": [
       {
-        "kanji": "話",
-        "mean": "THOẠI"
-      },
-      {
         "kanji": "電",
         "mean": "ĐIỆN"
+      },
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
       }
     ]
   },
@@ -400,12 +400,12 @@
     "example": "西口から出ます。",
     "kanji_search_results": [
       {
-        "kanji": "口",
-        "mean": "KHẨU"
-      },
-      {
         "kanji": "西",
         "mean": "TÂY, TÊ"
+      },
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
       }
     ]
   },
@@ -480,12 +480,12 @@
     "example": "教会で結婚式をします。",
     "kanji_search_results": [
       {
-        "kanji": "会",
-        "mean": "HỘI, CỐI"
-      },
-      {
         "kanji": "教",
         "mean": "GIÁO, GIAO"
+      },
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
       }
     ]
   },
@@ -552,12 +552,12 @@
     "example": "お土産を買います。",
     "kanji_search_results": [
       {
-        "kanji": "産",
-        "mean": "SẢN"
-      },
-      {
         "kanji": "土",
         "mean": "THỔ, ĐỘ, ĐỖ"
+      },
+      {
+        "kanji": "産",
+        "mean": "SẢN"
       }
     ]
   },

--- a/data/lesson_8_vocabulary.json
+++ b/data/lesson_8_vocabulary.json
@@ -7,7 +7,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "男の子が遊んでいます。"
+    "example": "男の子が遊んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "男",
+        "mean": "NAM"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "おとこの ひと",
@@ -17,7 +27,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "男の人が働いています。"
+    "example": "男の人が働いています。",
+    "kanji_search_results": [
+      {
+        "kanji": "男",
+        "mean": "NAM"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "おとこ",
@@ -27,7 +47,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "男の先生です。"
+    "example": "男の先生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "男",
+        "mean": "NAM"
+      }
+    ]
   },
   {
     "japanese": "おんなの こ",
@@ -37,7 +63,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "女の子が歌っています。"
+    "example": "女の子が歌っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "女",
+        "mean": "NỮ, NỨ, NHỮ"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "おんなの ひと",
@@ -47,7 +83,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "女の人が教えています。"
+    "example": "女の人が教えています。",
+    "kanji_search_results": [
+      {
+        "kanji": "女",
+        "mean": "NỮ, NỨ, NHỮ"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "おんな",
@@ -57,7 +103,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "女の学生です。"
+    "example": "女の学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "女",
+        "mean": "NỮ, NỨ, NHỮ"
+      }
+    ]
   },
   {
     "japanese": "こども",
@@ -67,7 +119,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "person",
-    "example": "子供が遊んでいます。"
+    "example": "子供が遊んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "供",
+        "mean": "CUNG"
+      },
+      {
+        "kanji": "子",
+        "mean": "TỬ, TÍ"
+      }
+    ]
   },
   {
     "japanese": "いぬ",
@@ -77,7 +139,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "animal",
-    "example": "犬が走っています。"
+    "example": "犬が走っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "犬",
+        "mean": "KHUYỂN"
+      }
+    ]
   },
   {
     "japanese": "き",
@@ -87,7 +155,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "高い木があります。"
+    "example": "高い木があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "木",
+        "mean": "MỘC"
+      }
+    ]
   },
   {
     "japanese": "じどうはんばいき",
@@ -97,7 +171,29 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "object",
-    "example": "自動販売機でジュースを買います。"
+    "example": "自動販売機でジュースを買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
+      },
+      {
+        "kanji": "機",
+        "mean": "KI, CƠ"
+      },
+      {
+        "kanji": "売",
+        "mean": "MẠI"
+      },
+      {
+        "kanji": "販",
+        "mean": "PHIẾN, PHÁN"
+      },
+      {
+        "kanji": "自",
+        "mean": "TỰ"
+      }
+    ]
   },
   {
     "japanese": "ねこ",
@@ -107,7 +203,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "animal",
-    "example": "猫が寝ています。"
+    "example": "猫が寝ています。",
+    "kanji_search_results": [
+      {
+        "kanji": "猫",
+        "mean": "MIÊU"
+      }
+    ]
   },
   {
     "japanese": "はこ",
@@ -117,7 +219,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "object",
-    "example": "箱の中に本があります。"
+    "example": "箱の中に本があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "箱",
+        "mean": "TƯƠNG, SƯƠNG"
+      }
+    ]
   },
   {
     "japanese": "つくえ",
@@ -127,7 +235,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "object",
-    "example": "机の上に本があります。"
+    "example": "机の上に本があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "机",
+        "mean": "KY, CƠ"
+      }
+    ]
   },
   {
     "japanese": "パジャマ",
@@ -187,7 +301,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "交番で道を聞きます。"
+    "example": "交番で道を聞きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "交",
+        "mean": "GIAO"
+      },
+      {
+        "kanji": "番",
+        "mean": "PHIÊN, PHAN, BA, BÀ"
+      }
+    ]
   },
   {
     "japanese": "バスてい",
@@ -197,7 +321,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "バス停でバスを待ちます。"
+    "example": "バス停でバスを待ちます。",
+    "kanji_search_results": [
+      {
+        "kanji": "停",
+        "mean": "ĐÌNH"
+      }
+    ]
   },
   {
     "japanese": "ポスト",
@@ -217,7 +347,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "object",
-    "example": "電話をかけます。"
+    "example": "電話をかけます。",
+    "kanji_search_results": [
+      {
+        "kanji": "話",
+        "mean": "THOẠI"
+      },
+      {
+        "kanji": "電",
+        "mean": "ĐIỆN"
+      }
+    ]
   },
   {
     "japanese": "ロッカー",
@@ -257,7 +397,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "西口から出ます。"
+    "example": "西口から出ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      },
+      {
+        "kanji": "西",
+        "mean": "TÂY, TÊ"
+      }
+    ]
   },
   {
     "japanese": "ひがしぐち",
@@ -267,7 +417,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "東口で待ち合わせをします。"
+    "example": "東口で待ち合わせをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "東",
+        "mean": "ĐÔNG"
+      },
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      }
+    ]
   },
   {
     "japanese": "みなみぐち",
@@ -277,7 +437,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "南口から入ります。"
+    "example": "南口から入ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "南",
+        "mean": "NAM"
+      },
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      }
+    ]
   },
   {
     "japanese": "きたぐち",
@@ -287,7 +457,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "北口で会いましょう。"
+    "example": "北口で会いましょう。",
+    "kanji_search_results": [
+      {
+        "kanji": "北",
+        "mean": "BẮC"
+      },
+      {
+        "kanji": "口",
+        "mean": "KHẨU"
+      }
+    ]
   },
   {
     "japanese": "きょうかい",
@@ -297,7 +477,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "教会で結婚式をします。"
+    "example": "教会で結婚式をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "会",
+        "mean": "HỘI, CỐI"
+      },
+      {
+        "kanji": "教",
+        "mean": "GIÁO, GIAO"
+      }
+    ]
   },
   {
     "japanese": "みずうみ",
@@ -307,7 +497,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "湖でボートに乗ります。"
+    "example": "湖でボートに乗ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "湖",
+        "mean": "HỒ"
+      }
+    ]
   },
   {
     "japanese": "つり",
@@ -317,7 +513,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "釣りをします。"
+    "example": "釣りをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "釣",
+        "mean": "ĐIẾU"
+      }
+    ]
   },
   {
     "japanese": "どうぶつ",
@@ -327,7 +529,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "animal",
-    "example": "動物が好きです。"
+    "example": "動物が好きです。",
+    "kanji_search_results": [
+      {
+        "kanji": "動",
+        "mean": "ĐỘNG"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "みやげ",
@@ -337,7 +549,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "object",
-    "example": "お土産を買います。"
+    "example": "お土産を買います。",
+    "kanji_search_results": [
+      {
+        "kanji": "産",
+        "mean": "SẢN"
+      },
+      {
+        "kanji": "土",
+        "mean": "THỔ, ĐỘ, ĐỖ"
+      }
+    ]
   },
   {
     "japanese": "みせ",
@@ -347,7 +569,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "店で買い物をします。"
+    "example": "店で買い物をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "店",
+        "mean": "ĐIẾM"
+      }
+    ]
   },
   {
     "japanese": "うえ",
@@ -357,7 +585,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "机の上に本があります。"
+    "example": "机の上に本があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      }
+    ]
   },
   {
     "japanese": "した",
@@ -367,7 +601,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "机の下に猫がいます。"
+    "example": "机の下に猫がいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "下",
+        "mean": "HẠ, HÁ"
+      }
+    ]
   },
   {
     "japanese": "まえ",
@@ -377,7 +617,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "学校の前にバス停があります。"
+    "example": "学校の前にバス停があります。",
+    "kanji_search_results": [
+      {
+        "kanji": "前",
+        "mean": "TIỀN"
+      }
+    ]
   },
   {
     "japanese": "うしろ",
@@ -387,7 +633,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "後ろに立ってください。"
+    "example": "後ろに立ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "後",
+        "mean": "HẬU, HẤU"
+      }
+    ]
   },
   {
     "japanese": "なか",
@@ -397,7 +649,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "箱の中に何がありますか。"
+    "example": "箱の中に何がありますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "中",
+        "mean": "TRUNG, TRÚNG"
+      }
+    ]
   },
   {
     "japanese": "そと",
@@ -407,7 +665,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "外で遊びます。"
+    "example": "外で遊びます。",
+    "kanji_search_results": [
+      {
+        "kanji": "外",
+        "mean": "NGOẠI"
+      }
+    ]
   },
   {
     "japanese": "よこ",
@@ -417,7 +681,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "横に座ってください。"
+    "example": "横に座ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "横",
+        "mean": "HOÀNH, HOẠNH, QUÁNG"
+      }
+    ]
   },
   {
     "japanese": "となり",
@@ -427,7 +697,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "隣の家に住んでいます。"
+    "example": "隣の家に住んでいます。",
+    "kanji_search_results": [
+      {
+        "kanji": "隣",
+        "mean": "LÂN"
+      }
+    ]
   },
   {
     "japanese": "あいだ",
@@ -437,7 +713,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "二人の間にテーブルがあります。"
+    "example": "二人の間にテーブルがあります。",
+    "kanji_search_results": [
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      }
+    ]
   },
   {
     "japanese": "ちかく",
@@ -447,7 +729,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "position",
-    "example": "近くにコンビニがあります。"
+    "example": "近くにコンビニがあります。",
+    "kanji_search_results": [
+      {
+        "kanji": "近",
+        "mean": "CẬN, CẤN, KÍ"
+      }
+    ]
   },
   {
     "japanese": "あります",
@@ -477,7 +765,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "歌を歌います。"
+    "example": "歌を歌います。",
+    "kanji_search_results": [
+      {
+        "kanji": "歌",
+        "mean": "CA"
+      }
+    ]
   },
   {
     "japanese": "おどります",
@@ -487,7 +781,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "ダンスを踊ります。"
+    "example": "ダンスを踊ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "踊",
+        "mean": "DŨNG"
+      }
+    ]
   },
   {
     "japanese": "とおい",
@@ -497,7 +797,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "遠い国に行きます。"
+    "example": "遠い国に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "遠",
+        "mean": "VIỄN, VIỂN"
+      }
+    ]
   },
   {
     "japanese": "ちかい",
@@ -507,7 +813,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "近い駅で降ります。"
+    "example": "近い駅で降ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "近",
+        "mean": "CẬN, CẤN, KÍ"
+      }
+    ]
   },
   {
     "japanese": "いそがしい",
@@ -517,7 +829,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "忙しい一日でした。"
+    "example": "忙しい一日でした。",
+    "kanji_search_results": [
+      {
+        "kanji": "忙",
+        "mean": "MANG"
+      }
+    ]
   },
   {
     "japanese": "ひま",
@@ -527,7 +845,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "暇な時に映画を見ます。"
+    "example": "暇な時に映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "暇",
+        "mean": "HẠ"
+      }
+    ]
   },
   {
     "japanese": "ひとり",
@@ -537,7 +861,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "number",
-    "example": "一人で旅行します。"
+    "example": "一人で旅行します。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "ふたり",
@@ -547,7 +877,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "number",
-    "example": "二人で映画を見ます。"
+    "example": "二人で映画を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "－にん",
@@ -557,7 +893,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "number",
-    "example": "三人で食事をします。"
+    "example": "三人で食事をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "なんにん",
@@ -567,7 +909,17 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "question",
-    "example": "何人で来ますか。"
+    "example": "何人で来ますか。",
+    "kanji_search_results": [
+      {
+        "kanji": "何",
+        "mean": "HÀ"
+      },
+      {
+        "kanji": "人",
+        "mean": "NHÂN"
+      }
+    ]
   },
   {
     "japanese": "たくさん",
@@ -637,7 +989,13 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "はい、分かりました。"
+    "example": "はい、分かりました。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "また あした",
@@ -667,6 +1025,12 @@
     "lesson": 8,
     "difficulty": "beginner",
     "category": "place",
-    "example": "みどり駅で降ります。"
+    "example": "みどり駅で降ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "駅",
+        "mean": "DỊCH"
+      }
+    ]
   }
 ]

--- a/data/lesson_9_vocabulary.json
+++ b/data/lesson_9_vocabulary.json
@@ -17,7 +17,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "sport",
-    "example": "野球を見ます。"
+    "example": "野球を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "球",
+        "mean": "CẦU"
+      },
+      {
+        "kanji": "野",
+        "mean": "DÃ"
+      }
+    ]
   },
   {
     "japanese": "まんが",
@@ -27,7 +37,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "漫画を読みます。"
+    "example": "漫画を読みます。",
+    "kanji_search_results": [
+      {
+        "kanji": "画",
+        "mean": "HỌA, HOẠCH"
+      },
+      {
+        "kanji": "漫",
+        "mean": "MẠN, MAN"
+      }
+    ]
   },
   {
     "japanese": "そうじ",
@@ -37,7 +57,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "部屋を掃除します。"
+    "example": "部屋を掃除します。",
+    "kanji_search_results": [
+      {
+        "kanji": "除",
+        "mean": "TRỪ"
+      },
+      {
+        "kanji": "掃",
+        "mean": "TẢO"
+      }
+    ]
   },
   {
     "japanese": "せんたく",
@@ -47,7 +77,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "服を洗濯します。"
+    "example": "服を洗濯します。",
+    "kanji_search_results": [
+      {
+        "kanji": "濯",
+        "mean": "TRẠC"
+      },
+      {
+        "kanji": "洗",
+        "mean": "TẨY, TIỂN"
+      }
+    ]
   },
   {
     "japanese": "え",
@@ -57,7 +97,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "object",
-    "example": "きれいな絵です。"
+    "example": "きれいな絵です。",
+    "kanji_search_results": [
+      {
+        "kanji": "絵",
+        "mean": "HỘI"
+      }
+    ]
   },
   {
     "japanese": "うた",
@@ -67,7 +113,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "歌を歌います。"
+    "example": "歌を歌います。",
+    "kanji_search_results": [
+      {
+        "kanji": "歌",
+        "mean": "CA"
+      }
+    ]
   },
   {
     "japanese": "えいご",
@@ -77,7 +129,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "education",
-    "example": "英語を勉強します。"
+    "example": "英語を勉強します。",
+    "kanji_search_results": [
+      {
+        "kanji": "語",
+        "mean": "NGỮ, NGỨ"
+      },
+      {
+        "kanji": "英",
+        "mean": "ANH"
+      }
+    ]
   },
   {
     "japanese": "かたかな",
@@ -87,7 +149,21 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "education",
-    "example": "片仮名を覚えます。"
+    "example": "片仮名を覚えます。",
+    "kanji_search_results": [
+      {
+        "kanji": "仮",
+        "mean": "GIẢ"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      },
+      {
+        "kanji": "片",
+        "mean": "PHIẾN"
+      }
+    ]
   },
   {
     "japanese": "ひらがな",
@@ -97,7 +173,21 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "education",
-    "example": "平仮名を書きます。"
+    "example": "平仮名を書きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "平",
+        "mean": "BÌNH, BIỀN"
+      },
+      {
+        "kanji": "仮",
+        "mean": "GIẢ"
+      },
+      {
+        "kanji": "名",
+        "mean": "DANH"
+      }
+    ]
   },
   {
     "japanese": "アナウンス",
@@ -127,7 +217,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "object",
-    "example": "窓を開けます。"
+    "example": "窓を開けます。",
+    "kanji_search_results": [
+      {
+        "kanji": "窓",
+        "mean": "SONG"
+      }
+    ]
   },
   {
     "japanese": "かいもの",
@@ -137,7 +233,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "買い物に行きます。"
+    "example": "買い物に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "買",
+        "mean": "MÃI"
+      },
+      {
+        "kanji": "物",
+        "mean": "VẬT"
+      }
+    ]
   },
   {
     "japanese": "てんき",
@@ -147,7 +253,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "天気がいいです。"
+    "example": "天気がいいです。",
+    "kanji_search_results": [
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
+      },
+      {
+        "kanji": "天",
+        "mean": "THIÊN"
+      }
+    ]
   },
   {
     "japanese": "あめ",
@@ -157,7 +273,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "nature",
-    "example": "雨が降っています。"
+    "example": "雨が降っています。",
+    "kanji_search_results": [
+      {
+        "kanji": "雨",
+        "mean": "VŨ, VÚ"
+      }
+    ]
   },
   {
     "japanese": "ちゅうしゃ",
@@ -167,7 +289,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "health",
-    "example": "注射を受けます。"
+    "example": "注射を受けます。",
+    "kanji_search_results": [
+      {
+        "kanji": "射",
+        "mean": "XẠ, DẠ, DỊCH"
+      },
+      {
+        "kanji": "注",
+        "mean": "CHÚ"
+      }
+    ]
   },
   {
     "japanese": "じかん",
@@ -177,7 +309,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "time",
-    "example": "時間がありません。"
+    "example": "時間がありません。",
+    "kanji_search_results": [
+      {
+        "kanji": "間",
+        "mean": "GIAN"
+      },
+      {
+        "kanji": "時",
+        "mean": "THÌ, THỜI"
+      }
+    ]
   },
   {
     "japanese": "つうやく",
@@ -187,7 +329,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "work",
-    "example": "通訳をします。"
+    "example": "通訳をします。",
+    "kanji_search_results": [
+      {
+        "kanji": "通",
+        "mean": "THÔNG"
+      },
+      {
+        "kanji": "訳",
+        "mean": "DỊCH"
+      }
+    ]
   },
   {
     "japanese": "デート",
@@ -207,7 +359,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "noun",
-    "example": "約束を守ります。"
+    "example": "約束を守ります。",
+    "kanji_search_results": [
+      {
+        "kanji": "約",
+        "mean": "ƯỚC"
+      },
+      {
+        "kanji": "束",
+        "mean": "THÚC, THÚ"
+      }
+    ]
   },
   {
     "japanese": "やまのぼり",
@@ -217,7 +379,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "山登りをします。"
+    "example": "山登りをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
+      },
+      {
+        "kanji": "山",
+        "mean": "SAN, SƠN"
+      }
+    ]
   },
   {
     "japanese": "りょこう",
@@ -227,7 +399,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "activity",
-    "example": "旅行に行きます。"
+    "example": "旅行に行きます。",
+    "kanji_search_results": [
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
+      },
+      {
+        "kanji": "旅",
+        "mean": "LỮ"
+      }
+    ]
   },
   {
     "japanese": "ドラマ",
@@ -257,7 +439,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "work",
-    "example": "教師をしています。"
+    "example": "教師をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "教",
+        "mean": "GIÁO, GIAO"
+      },
+      {
+        "kanji": "師",
+        "mean": "SƯ"
+      }
+    ]
   },
   {
     "japanese": "モデル",
@@ -277,7 +469,21 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "work",
-    "example": "弁護士をしています。"
+    "example": "弁護士をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "弁",
+        "mean": "BIỆN, BIỀN, BÀN"
+      },
+      {
+        "kanji": "護",
+        "mean": "HỘ"
+      },
+      {
+        "kanji": "士",
+        "mean": "SĨ"
+      }
+    ]
   },
   {
     "japanese": "せんしゅ",
@@ -287,7 +493,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "work",
-    "example": "選手をしています。"
+    "example": "選手をしています。",
+    "kanji_search_results": [
+      {
+        "kanji": "選",
+        "mean": "TUYỂN, TUYẾN"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "サッカーせんしゅ",
@@ -297,7 +513,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "work",
-    "example": "サッカー選手です。"
+    "example": "サッカー選手です。",
+    "kanji_search_results": [
+      {
+        "kanji": "選",
+        "mean": "TUYỂN, TUYẾN"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "ミュージシャン",
@@ -317,7 +543,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "番組を見ます。"
+    "example": "番組を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "組",
+        "mean": "TỔ"
+      },
+      {
+        "kanji": "番",
+        "mean": "PHIÊN, PHAN, BA, BÀ"
+      }
+    ]
   },
   {
     "japanese": "テレビばんぐみ",
@@ -327,7 +563,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "entertainment",
-    "example": "テレビ番組を見ます。"
+    "example": "テレビ番組を見ます。",
+    "kanji_search_results": [
+      {
+        "kanji": "組",
+        "mean": "TỔ"
+      },
+      {
+        "kanji": "番",
+        "mean": "PHIÊN, PHAN, BA, BÀ"
+      }
+    ]
   },
   {
     "japanese": "おとうさん",
@@ -337,7 +583,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "お父さんは会社員です。"
+    "example": "お父さんは会社員です。",
+    "kanji_search_results": [
+      {
+        "kanji": "父",
+        "mean": "PHỤ, PHỦ"
+      }
+    ]
   },
   {
     "japanese": "おかあさん",
@@ -347,7 +599,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "お母さんは教師です。"
+    "example": "お母さんは教師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "母",
+        "mean": "MẪU, MÔ"
+      }
+    ]
   },
   {
     "japanese": "おにいさん",
@@ -357,7 +615,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "お兄さんは大学生です。"
+    "example": "お兄さんは大学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "兄",
+        "mean": "HUYNH"
+      }
+    ]
   },
   {
     "japanese": "おねえさん",
@@ -367,7 +631,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "お姉さんは看護師です。"
+    "example": "お姉さんは看護師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "姉",
+        "mean": "TỈ"
+      }
+    ]
   },
   {
     "japanese": "おとうとさん",
@@ -377,7 +647,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "弟さんは高校生です。"
+    "example": "弟さんは高校生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "弟",
+        "mean": "ĐỆ, ĐỄ"
+      }
+    ]
   },
   {
     "japanese": "いもうとさん",
@@ -387,7 +663,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "妹さんは中学生です。"
+    "example": "妹さんは中学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "妹",
+        "mean": "MUỘI"
+      }
+    ]
   },
   {
     "japanese": "ちち",
@@ -397,7 +679,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "父は医者です。"
+    "example": "父は医者です。",
+    "kanji_search_results": [
+      {
+        "kanji": "父",
+        "mean": "PHỤ, PHỦ"
+      }
+    ]
   },
   {
     "japanese": "はは",
@@ -407,7 +695,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "母は看護師です。"
+    "example": "母は看護師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "母",
+        "mean": "MẪU, MÔ"
+      }
+    ]
   },
   {
     "japanese": "あに",
@@ -417,7 +711,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "兄は会社員です。"
+    "example": "兄は会社員です。",
+    "kanji_search_results": [
+      {
+        "kanji": "兄",
+        "mean": "HUYNH"
+      }
+    ]
   },
   {
     "japanese": "あね",
@@ -427,7 +727,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "姉は教師です。"
+    "example": "姉は教師です。",
+    "kanji_search_results": [
+      {
+        "kanji": "姉",
+        "mean": "TỈ"
+      }
+    ]
   },
   {
     "japanese": "おとうと",
@@ -437,7 +743,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "弟は大学生です。"
+    "example": "弟は大学生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "弟",
+        "mean": "ĐỆ, ĐỄ"
+      }
+    ]
   },
   {
     "japanese": "いもうと",
@@ -447,7 +759,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "妹は高校生です。"
+    "example": "妹は高校生です。",
+    "kanji_search_results": [
+      {
+        "kanji": "妹",
+        "mean": "MUỘI"
+      }
+    ]
   },
   {
     "japanese": "かぞく",
@@ -457,7 +775,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "ご家族は何人ですか。"
+    "example": "ご家族は何人ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "家",
+        "mean": "GIA, CÔ"
+      },
+      {
+        "kanji": "族",
+        "mean": "TỘC"
+      }
+    ]
   },
   {
     "japanese": "りょうしん",
@@ -467,7 +795,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "family",
-    "example": "ご両親はお元気ですか。"
+    "example": "ご両親はお元気ですか。",
+    "kanji_search_results": [
+      {
+        "kanji": "両",
+        "mean": "LƯỠNG, LẠNG"
+      },
+      {
+        "kanji": "親",
+        "mean": "THÂN, THẤN"
+      }
+    ]
   },
   {
     "japanese": "かきます",
@@ -477,7 +815,29 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "絵をかきます。"
+    "example": "絵をかきます。",
+    "kanji_search_results": [
+      {
+        "kanji": "隠",
+        "mean": "ẨN"
+      },
+      {
+        "kanji": "薆",
+        "mean": ""
+      },
+      {
+        "kanji": "廋",
+        "mean": "SƯU"
+      },
+      {
+        "kanji": "乚",
+        "mean": ""
+      },
+      {
+        "kanji": "戽",
+        "mean": "HỐ"
+      }
+    ]
   },
   {
     "japanese": "わかります",
@@ -487,7 +847,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "日本語が分かります。"
+    "example": "日本語が分かります。",
+    "kanji_search_results": [
+      {
+        "kanji": "分",
+        "mean": "PHÂN, PHẬN"
+      }
+    ]
   },
   {
     "japanese": "あけます",
@@ -497,7 +863,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "窓を開けます。"
+    "example": "窓を開けます。",
+    "kanji_search_results": [
+      {
+        "kanji": "開",
+        "mean": "KHAI"
+      }
+    ]
   },
   {
     "japanese": "さんぽします",
@@ -507,7 +879,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "公園を散歩します。"
+    "example": "公園を散歩します。",
+    "kanji_search_results": [
+      {
+        "kanji": "歩",
+        "mean": "BỘ"
+      },
+      {
+        "kanji": "散",
+        "mean": "TÁN, TẢN"
+      }
+    ]
   },
   {
     "japanese": "おみあいします",
@@ -517,7 +899,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "verb",
-    "example": "お見合いをします。"
+    "example": "お見合いをします。",
+    "kanji_search_results": [
+      {
+        "kanji": "合",
+        "mean": "HỢP, CÁP, HIỆP"
+      },
+      {
+        "kanji": "見",
+        "mean": "KIẾN, HIỆN"
+      }
+    ]
   },
   {
     "japanese": "あまい",
@@ -527,7 +919,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "甘いケーキです。"
+    "example": "甘いケーキです。",
+    "kanji_search_results": [
+      {
+        "kanji": "甘",
+        "mean": "CAM"
+      }
+    ]
   },
   {
     "japanese": "からい",
@@ -537,7 +935,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "辛い料理です。"
+    "example": "辛い料理です。",
+    "kanji_search_results": [
+      {
+        "kanji": "辛",
+        "mean": "TÂN"
+      }
+    ]
   },
   {
     "japanese": "あつい",
@@ -547,7 +951,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "今日は暑いです。"
+    "example": "今日は暑いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "暑",
+        "mean": "THỬ"
+      }
+    ]
   },
   {
     "japanese": "さむい",
@@ -557,7 +967,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "冬は寒いです。"
+    "example": "冬は寒いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "寒",
+        "mean": "HÀN"
+      }
+    ]
   },
   {
     "japanese": "ねむい",
@@ -567,7 +983,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "眠いです。"
+    "example": "眠いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "眠",
+        "mean": "MIÊN"
+      }
+    ]
   },
   {
     "japanese": "すき",
@@ -577,7 +999,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "音楽が好きです。"
+    "example": "音楽が好きです。",
+    "kanji_search_results": [
+      {
+        "kanji": "好",
+        "mean": "HẢO, HIẾU"
+      }
+    ]
   },
   {
     "japanese": "きらい",
@@ -587,7 +1015,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "野菜が嫌いです。"
+    "example": "野菜が嫌いです。",
+    "kanji_search_results": [
+      {
+        "kanji": "嫌",
+        "mean": "HIỀM"
+      }
+    ]
   },
   {
     "japanese": "じょうず",
@@ -597,7 +1031,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "ピアノが上手です。"
+    "example": "ピアノが上手です。",
+    "kanji_search_results": [
+      {
+        "kanji": "上",
+        "mean": "THƯỢNG, THƯỚNG"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      }
+    ]
   },
   {
     "japanese": "へた",
@@ -607,7 +1051,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "歌が下手です。"
+    "example": "歌が下手です。",
+    "kanji_search_results": [
+      {
+        "kanji": "手",
+        "mean": "THỦ"
+      },
+      {
+        "kanji": "下",
+        "mean": "HẠ, HÁ"
+      }
+    ]
   },
   {
     "japanese": "ざんねん",
@@ -617,7 +1071,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adjective",
-    "example": "残念です。"
+    "example": "残念です。",
+    "kanji_search_results": [
+      {
+        "kanji": "念",
+        "mean": "NIỆM"
+      },
+      {
+        "kanji": "残",
+        "mean": "TÀN"
+      }
+    ]
   },
   {
     "japanese": "どうして",
@@ -637,7 +1101,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "少し待ってください。"
+    "example": "少し待ってください。",
+    "kanji_search_results": [
+      {
+        "kanji": "少",
+        "mean": "THIỂU, THIẾU"
+      }
+    ]
   },
   {
     "japanese": "だいたい",
@@ -667,7 +1137,17 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "全然分かりません。"
+    "example": "全然分かりません。",
+    "kanji_search_results": [
+      {
+        "kanji": "然",
+        "mean": "NHIÊN"
+      },
+      {
+        "kanji": "全",
+        "mean": "TOÀN"
+      }
+    ]
   },
   {
     "japanese": "はやく",
@@ -677,7 +1157,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "adverb",
-    "example": "早く来てください。"
+    "example": "早く来てください。",
+    "kanji_search_results": [
+      {
+        "kanji": "早",
+        "mean": "TẢO"
+      }
+    ]
   },
   {
     "japanese": "うーん",
@@ -727,7 +1213,13 @@
     "lesson": 9,
     "difficulty": "beginner",
     "category": "expression",
-    "example": "よろしくお願いします。"
+    "example": "よろしくお願いします。",
+    "kanji_search_results": [
+      {
+        "kanji": "願",
+        "mean": "NGUYỆN"
+      }
+    ]
   },
   {
     "japanese": "スペイン",

--- a/data/lesson_9_vocabulary.json
+++ b/data/lesson_9_vocabulary.json
@@ -20,12 +20,12 @@
     "example": "野球を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "球",
-        "mean": "CẦU"
-      },
-      {
         "kanji": "野",
         "mean": "DÃ"
+      },
+      {
+        "kanji": "球",
+        "mean": "CẦU"
       }
     ]
   },
@@ -40,12 +40,12 @@
     "example": "漫画を読みます。",
     "kanji_search_results": [
       {
-        "kanji": "画",
-        "mean": "HỌA, HOẠCH"
-      },
-      {
         "kanji": "漫",
         "mean": "MẠN, MAN"
+      },
+      {
+        "kanji": "画",
+        "mean": "HỌA, HOẠCH"
       }
     ]
   },
@@ -60,12 +60,12 @@
     "example": "部屋を掃除します。",
     "kanji_search_results": [
       {
-        "kanji": "除",
-        "mean": "TRỪ"
-      },
-      {
         "kanji": "掃",
         "mean": "TẢO"
+      },
+      {
+        "kanji": "除",
+        "mean": "TRỪ"
       }
     ]
   },
@@ -80,12 +80,12 @@
     "example": "服を洗濯します。",
     "kanji_search_results": [
       {
-        "kanji": "濯",
-        "mean": "TRẠC"
-      },
-      {
         "kanji": "洗",
         "mean": "TẨY, TIỂN"
+      },
+      {
+        "kanji": "濯",
+        "mean": "TRẠC"
       }
     ]
   },
@@ -132,12 +132,12 @@
     "example": "英語を勉強します。",
     "kanji_search_results": [
       {
-        "kanji": "語",
-        "mean": "NGỮ, NGỨ"
-      },
-      {
         "kanji": "英",
         "mean": "ANH"
+      },
+      {
+        "kanji": "語",
+        "mean": "NGỮ, NGỨ"
       }
     ]
   },
@@ -152,16 +152,16 @@
     "example": "片仮名を覚えます。",
     "kanji_search_results": [
       {
+        "kanji": "片",
+        "mean": "PHIẾN"
+      },
+      {
         "kanji": "仮",
         "mean": "GIẢ"
       },
       {
         "kanji": "名",
         "mean": "DANH"
-      },
-      {
-        "kanji": "片",
-        "mean": "PHIẾN"
       }
     ]
   },
@@ -256,12 +256,12 @@
     "example": "天気がいいです。",
     "kanji_search_results": [
       {
-        "kanji": "気",
-        "mean": "KHÍ"
-      },
-      {
         "kanji": "天",
         "mean": "THIÊN"
+      },
+      {
+        "kanji": "気",
+        "mean": "KHÍ"
       }
     ]
   },
@@ -292,12 +292,12 @@
     "example": "注射を受けます。",
     "kanji_search_results": [
       {
-        "kanji": "射",
-        "mean": "XẠ, DẠ, DỊCH"
-      },
-      {
         "kanji": "注",
         "mean": "CHÚ"
+      },
+      {
+        "kanji": "射",
+        "mean": "XẠ, DẠ, DỊCH"
       }
     ]
   },
@@ -312,12 +312,12 @@
     "example": "時間がありません。",
     "kanji_search_results": [
       {
-        "kanji": "間",
-        "mean": "GIAN"
-      },
-      {
         "kanji": "時",
         "mean": "THÌ, THỜI"
+      },
+      {
+        "kanji": "間",
+        "mean": "GIAN"
       }
     ]
   },
@@ -382,12 +382,12 @@
     "example": "山登りをします。",
     "kanji_search_results": [
       {
-        "kanji": "登",
-        "mean": "ĐĂNG"
-      },
-      {
         "kanji": "山",
         "mean": "SAN, SƠN"
+      },
+      {
+        "kanji": "登",
+        "mean": "ĐĂNG"
       }
     ]
   },
@@ -402,12 +402,12 @@
     "example": "旅行に行きます。",
     "kanji_search_results": [
       {
-        "kanji": "行",
-        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
-      },
-      {
         "kanji": "旅",
         "mean": "LỮ"
+      },
+      {
+        "kanji": "行",
+        "mean": "HÀNH, HẠNH, HÀNG, HẠNG"
       }
     ]
   },
@@ -546,12 +546,12 @@
     "example": "番組を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "組",
-        "mean": "TỔ"
-      },
-      {
         "kanji": "番",
         "mean": "PHIÊN, PHAN, BA, BÀ"
+      },
+      {
+        "kanji": "組",
+        "mean": "TỔ"
       }
     ]
   },
@@ -566,12 +566,12 @@
     "example": "テレビ番組を見ます。",
     "kanji_search_results": [
       {
-        "kanji": "組",
-        "mean": "TỔ"
-      },
-      {
         "kanji": "番",
         "mean": "PHIÊN, PHAN, BA, BÀ"
+      },
+      {
+        "kanji": "組",
+        "mean": "TỔ"
       }
     ]
   },
@@ -882,12 +882,12 @@
     "example": "公園を散歩します。",
     "kanji_search_results": [
       {
-        "kanji": "歩",
-        "mean": "BỘ"
-      },
-      {
         "kanji": "散",
         "mean": "TÁN, TẢN"
+      },
+      {
+        "kanji": "歩",
+        "mean": "BỘ"
       }
     ]
   },
@@ -902,12 +902,12 @@
     "example": "お見合いをします。",
     "kanji_search_results": [
       {
-        "kanji": "合",
-        "mean": "HỢP, CÁP, HIỆP"
-      },
-      {
         "kanji": "見",
         "mean": "KIẾN, HIỆN"
+      },
+      {
+        "kanji": "合",
+        "mean": "HỢP, CÁP, HIỆP"
       }
     ]
   },
@@ -1054,12 +1054,12 @@
     "example": "歌が下手です。",
     "kanji_search_results": [
       {
-        "kanji": "手",
-        "mean": "THỦ"
-      },
-      {
         "kanji": "下",
         "mean": "HẠ, HÁ"
+      },
+      {
+        "kanji": "手",
+        "mean": "THỦ"
       }
     ]
   },
@@ -1074,12 +1074,12 @@
     "example": "残念です。",
     "kanji_search_results": [
       {
-        "kanji": "念",
-        "mean": "NIỆM"
-      },
-      {
         "kanji": "残",
         "mean": "TÀN"
+      },
+      {
+        "kanji": "念",
+        "mean": "NIỆM"
       }
     ]
   },
@@ -1140,12 +1140,12 @@
     "example": "全然分かりません。",
     "kanji_search_results": [
       {
-        "kanji": "然",
-        "mean": "NHIÊN"
-      },
-      {
         "kanji": "全",
         "mean": "TOÀN"
+      },
+      {
+        "kanji": "然",
+        "mean": "NHIÊN"
       }
     ]
   },

--- a/flashcard.html
+++ b/flashcard.html
@@ -13,11 +13,29 @@
         .vietnamese-text { font-family: 'Inter', sans-serif; }
         
         .card-flip-animation {
-            transition: transform 0.6s;
+            transition: transform 0.9s;
             transform-style: preserve-3d;
         }
         
         .card-flip-animation.flipped {
+            transform: rotateY(180deg);
+        }
+
+        /* 3D flip container and faces */
+        .card-3d-container {
+            perspective: 1000px;
+        }
+        .card-face {
+            backface-visibility: hidden;
+            -webkit-backface-visibility: hidden;
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+        }
+        .card-back-3d {
             transform: rotateY(180deg);
         }
 
@@ -101,16 +119,23 @@
                         <strong>Phím tắt:</strong> ← → (chuyển thẻ) | Enter/Click (lật thẻ qua lại) | 1,2,3 (đánh giá) | Space (tiếp theo)
                     </div>
                     
-                    <div id="flashcard" class="bg-gradient-to-br from-pink-50 to-blue-50 rounded-xl p-8 mb-6 min-h-80 flex items-center justify-center cursor-pointer shadow-lg hover:shadow-xl transition-all card-flip-animation">
-                        <div id="card-front" class="text-center">
-                            <div class="japanese-text text-4xl font-medium text-gray-800 mb-4" id="japanese-word">Chọn bài học để bắt đầu</div>
-                            <div class="text-gray-500 text-sm">Nhấn Enter hoặc click để xem nghĩa</div>
-                        </div>
-                        <div id="card-back" class="text-center hidden">
-                            <div class="text-2xl font-medium text-gray-800 mb-2" id="vietnamese-meaning">Nghĩa tiếng Việt</div>
-                            <div class="text-gray-600 text-sm mb-2" id="romanji-text">Romanji</div>
-                            <div class="text-gray-500 text-xs italic mb-4" id="usage-note">Ví dụ</div>
-                            <div class="text-gray-500 text-sm">Nhấn để xem lại tiếng Nhật</div>
+                    <div class="card-3d-container rounded-xl mb-6">
+                        <div id="flashcard" class="relative bg-gradient-to-br from-pink-50 to-blue-50 rounded-xl p-8 min-h-80 flex items-center justify-center cursor-pointer shadow-lg hover:shadow-xl transition-all card-flip-animation">
+                            <div id="card-front" class="card-face text-center">
+                                <div class="japanese-text text-4xl font-medium text-gray-800 mb-2" id="japanese-word">Chọn bài học để bắt đầu</div>
+                                <div id="kanji-text" class="japanese-text text-3xl text-gray-600 mb-3 hidden"></div>
+                                <div class="text-gray-500 text-sm">Nhấn Enter hoặc click để xem nghĩa</div>
+                            </div>
+                            <div id="card-back" class="card-face card-back-3d text-center">
+                                <div class="text-2xl font-medium text-gray-800 mb-2" id="vietnamese-meaning">Nghĩa tiếng Việt</div>
+                                <div class="text-gray-600 text-sm mb-2" id="romanji-text">Romanji</div>
+                                <div id="hanviet-section" class="w-full max-w-md text-center hidden mb-2">
+                                    <div class="text-xs text-gray-400 mb-1">Hán‑Việt:</div>
+                                    <div id="hanviet-list" class="space-y-1"></div>
+                                </div>
+                                <div class="text-gray-500 text-xs italic mb-4" id="usage-note">Ví dụ</div>
+                                <div class="text-gray-500 text-sm">Nhấn để xem lại tiếng Nhật</div>
+                            </div>
                         </div>
                     </div>
 

--- a/flashcard.js
+++ b/flashcard.js
@@ -231,31 +231,49 @@ class FlashcardApp {
         
         // Reset card state
         this.isCardFlipped = false;
-        document.getElementById('card-front').classList.remove('hidden');
-        document.getElementById('card-back').classList.add('hidden');
+        const card = document.getElementById('flashcard');
+        if (card) card.classList.remove('flipped');
         
         // Cập nhật nội dung thẻ
         document.getElementById('japanese-word').textContent = word.japanese || '';
         document.getElementById('vietnamese-meaning').textContent = word.vietnamese || '';
         document.getElementById('romanji-text').textContent = word.romanji || '';
         document.getElementById('usage-note').textContent = word.example || '';
+
+        // Show Kanji on front if available
+        const kanjiTextEl = document.getElementById('kanji-text');
+        if (kanjiTextEl) {
+            const hasKanji = typeof word.kanji === 'string' && word.kanji.trim().length > 0;
+            kanjiTextEl.textContent = hasKanji ? word.kanji : '';
+            kanjiTextEl.classList.toggle('hidden', !hasKanji);
+        }
+
+        // Show Hán-Việt meanings on back if available
+        const hvSection = document.getElementById('hanviet-section');
+        const hvList = document.getElementById('hanviet-list');
+        if (hvSection && hvList) {
+            const list = Array.isArray(word.kanji_search_results) ? word.kanji_search_results.slice(0, 5) : [];
+            if (list.length) {
+                hvList.innerHTML = list.map(r => `
+                    <div class=\"text-sm text-gray-700\"><span class=\"japanese-text mr-2\">${r.kanji}</span><span class=\"text-gray-600\">${r.mean}</span></div>
+                `).join('');
+                hvSection.classList.remove('hidden');
+            } else {
+                hvList.innerHTML = '';
+                hvSection.classList.add('hidden');
+            }
+        }
     }
 
     // Lật thẻ
     flipCard() {
-        const cardFront = document.getElementById('card-front');
-        const cardBack = document.getElementById('card-back');
-        
-        if (!this.isCardFlipped) {
-            // Lật từ mặt trước sang mặt sau
-            cardFront.classList.add('hidden');
-            cardBack.classList.remove('hidden');
-            this.isCardFlipped = true;
+        const card = document.getElementById('flashcard');
+        if (!card) return;
+        this.isCardFlipped = !this.isCardFlipped;
+        if (this.isCardFlipped) {
+            card.classList.add('flipped');
         } else {
-            // Lật từ mặt sau sang mặt trước
-            cardBack.classList.add('hidden');
-            cardFront.classList.remove('hidden');
-            this.isCardFlipped = false;
+            card.classList.remove('flipped');
         }
     }
 

--- a/lessons.js
+++ b/lessons.js
@@ -226,33 +226,47 @@ class LessonsApp {
         }
 
         container.innerHTML = this.filteredVocabulary.map(word => `
-            <div class="vocab-card bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 hover:shadow-md transition-all duration-300">
-                <!-- Header: Japanese & Kanji -->
-                <div class="flex items-start justify-between mb-3">
-                    <div class="flex-1 min-w-0">
-                        <div class="japanese-text text-xl md:text-2xl font-medium text-gray-800 mb-1 break-all">${word.japanese}</div>
-                        ${word.kanji ? `<div class="japanese-text text-lg md:text-xl text-gray-600 mb-2 break-all">${word.kanji}</div>` : ''}
+            <div class="vocab-card bg-white rounded-lg shadow-sm border border-gray-200 p-4 md:p-6 hover:shadow-md transition-all duration-300 h-full min-h-64 flex flex-col">
+                <div class="flex-1 flex flex-col">
+                    <!-- Header: Japanese & Kanji -->
+                    <div class="flex items-start justify-between mb-3">
+                        <div class="flex-1 min-w-0">
+                            <div class="japanese-text text-xl md:text-2xl font-medium text-gray-800 mb-1 break-all">${word.japanese}</div>
+                            ${word.kanji ? `<div class="japanese-text text-lg md:text-xl text-gray-600 mb-2 break-all">${word.kanji}</div>` : ''}
+                        </div>
+                        <div class="flex-shrink-0 ml-3">
+                            ${word.category ? `<span class="inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2 py-1 rounded-full whitespace-nowrap">${word.category}</span>` : ''}
+                        </div>
                     </div>
-                    <div class="flex-shrink-0 ml-3">
-                        ${word.category ? `<span class="inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2 py-1 rounded-full whitespace-nowrap">${word.category}</span>` : ''}
-                    </div>
+                    
+                    <!-- Vietnamese Meaning -->
+                    <div class="text-gray-700 font-medium mb-2 text-base md:text-lg">${word.vietnamese}</div>
+                    
+                    <!-- Romanji -->
+                    ${word.romanji ? `<div class="text-sm text-gray-500 mb-3 italic">${word.romanji}</div>` : ''}
+
+                    <!-- Hán Việt (from kanji_search_results) -->
+                    ${Array.isArray(word.kanji_search_results) && word.kanji_search_results.length ? `
+                        <div class="mt-3 pt-3 border-t border-gray-100">
+                            <div class="text-xs text-gray-400 mb-1">Hán Việt:</div>
+                            <div class="space-y-1">
+                                ${word.kanji_search_results.slice(0, 5).map(r => `
+                                    <div class=\"text-sm text-gray-700\"><span class=\"japanese-text mr-2\">${r.kanji}</span><span class=\"text-gray-600\">${r.mean}</span></div>
+                                `).join('')}
+                            </div>
+                        </div>
+                    ` : ''}
+                    
+                    <!-- Example -->
+                    ${word.example ? `
+                        <div class="mt-3 pt-3 border-t border-gray-100">
+                            <div class="text-xs text-gray-400 mb-1">Ví dụ:</div>
+                            <div class="japanese-text text-sm text-gray-600 italic">"${word.example}"</div>
+                        </div>
+                    ` : ''}
                 </div>
                 
-                <!-- Vietnamese Meaning -->
-                <div class="text-gray-700 font-medium mb-2 text-base md:text-lg">${word.vietnamese}</div>
-                
-                <!-- Romanji -->
-                ${word.romanji ? `<div class="text-sm text-gray-500 mb-3 italic">${word.romanji}</div>` : ''}
-                
-                <!-- Example -->
-                ${word.example ? `
-                    <div class="mt-3 pt-3 border-t border-gray-100">
-                        <div class="text-xs text-gray-400 mb-1">Ví dụ:</div>
-                        <div class="japanese-text text-sm text-gray-600 italic">"${word.example}"</div>
-                    </div>
-                ` : ''}
-                
-                <!-- Difficulty Badge -->
+                <!-- Difficulty Badge (sticky bottom) -->
                 ${word.difficulty ? `
                     <div class="mt-3 flex justify-end">
                         <span class="inline-block px-2 py-1 text-xs font-medium rounded-full ${

--- a/reorder_kanji_results.js
+++ b/reorder_kanji_results.js
@@ -1,0 +1,90 @@
+// Reorder kanji_search_results to match the order of characters in `kanji`
+// Applies to lesson files: data/lesson_1_vocabulary.json .. data/lesson_22_vocabulary.json
+
+const fs = require('fs');
+const path = require('path');
+
+const LESSON_DIR = path.join(__dirname, 'data');
+const FILE_PREFIX = 'lesson_';
+const FILE_SUFFIX = '_vocabulary.json';
+const START = 1;
+const END = 22;
+
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeJson(filePath, data) {
+  const content = JSON.stringify(data, null, 2) + '\n';
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function reorderKanjiResultsForEntry(entry) {
+  const kanjiText = typeof entry.kanji === 'string' ? entry.kanji.trim() : '';
+  const results = Array.isArray(entry.kanji_search_results) ? entry.kanji_search_results.slice() : null;
+  if (!kanjiText || !results || results.length === 0) return false;
+
+  // Build order mapping based on first occurrence of each kanji character in the string
+  const order = [];
+  for (const ch of kanjiText) {
+    if (/\s/.test(ch)) continue; // skip spaces
+    order.push(ch);
+  }
+
+  const used = new Array(results.length).fill(false);
+  const ordered = [];
+
+  // For each character in `kanji`, pick the first matching result not used yet
+  for (const ch of order) {
+    const idx = results.findIndex((r, i) => !used[i] && typeof r.kanji === 'string' && r.kanji === ch);
+    if (idx !== -1) {
+      ordered.push(results[idx]);
+      used[idx] = true;
+    }
+  }
+
+  // Append any remaining unmatched results at the end (stable order)
+  for (let i = 0; i < results.length; i++) {
+    if (!used[i]) ordered.push(results[i]);
+  }
+
+  // Only update if order changed
+  const changed = JSON.stringify(results) !== JSON.stringify(ordered);
+  if (changed) entry.kanji_search_results = ordered;
+  return changed;
+}
+
+function processFile(filePath) {
+  const data = readJson(filePath);
+  if (!Array.isArray(data)) return { changed: false, count: 0 };
+  let changedCount = 0;
+  for (const entry of data) {
+    if (reorderKanjiResultsForEntry(entry)) changedCount++;
+  }
+  if (changedCount > 0) writeJson(filePath, data);
+  return { changed: changedCount > 0, count: changedCount };
+}
+
+function main() {
+  let totalChanged = 0;
+  for (let n = START; n <= END; n++) {
+    const file = path.join(LESSON_DIR, `${FILE_PREFIX}${n}${FILE_SUFFIX}`);
+    if (!fs.existsSync(file)) {
+      console.warn(`Missing file: ${file}`);
+      continue;
+    }
+    const { changed, count } = processFile(file);
+    if (changed) {
+      console.log(`Reordered ${count} entries in ${path.basename(file)}`);
+      totalChanged += count;
+    } else {
+      console.log(`No changes in ${path.basename(file)}`);
+    }
+  }
+  console.log(`Done. Total entries reordered: ${totalChanged}`);
+}
+
+main();
+
+


### PR DESCRIPTION
**Description**

- Render Hán‑Việt meanings from kanji_search_results in lessons.js (max 5 items per word).
- Standardize card layout: flex‑column structure, consistent height, difficulty badge anchored at the bottom.
- Add augment_kanji.js to fetch Mazii API and populate kanji_search_results for lessons 1–22.

**Changes**

- lessons.js: add Hán‑Việt block; adjust card structure for alignment.
- augment_kanji.js: Node script to call Mazii API and update lesson JSON.